### PR TITLE
Make the plugin feature usable: surface failures, fix footguns, ship an example

### DIFF
--- a/Sources/FinderTwo/Plugins/PluginHost.swift
+++ b/Sources/FinderTwo/Plugins/PluginHost.swift
@@ -62,6 +62,11 @@ final class PluginHost {
 
     private(set) var plugins: [LoadedPlugin] = []
 
+    /// Why a `.ftplugin` bundle failed to load on the last `loadAll()`. Surfaced
+    /// in the Reload-Plugins summary so a broken plugin isn't a silent no-op.
+    struct LoadFailure { let bundle: String; let reason: String }
+    private(set) var failures: [LoadFailure] = []
+
     static var pluginsDirectory: URL {
         let home = FileManager.default.homeDirectoryForCurrentUser
         return home
@@ -72,6 +77,7 @@ final class PluginHost {
     /// reloads from disk.
     func loadAll() {
         plugins = []
+        failures = []
         let dir = PluginHost.pluginsDirectory
         guard let kids = try? FileManager.default.contentsOfDirectory(at: dir,
             includingPropertiesForKeys: nil) else { return }
@@ -83,20 +89,40 @@ final class PluginHost {
     /// Test hook: load a single plugin bundle from an arbitrary directory.
     func testLoad(at dir: URL) { loadPlugin(at: dir) }
 
+    private func recordFailure(_ bundle: String, _ reason: String) {
+        failures.append(LoadFailure(bundle: bundle, reason: reason))
+        NSLog("FT plugin load failed [%@]: %@", bundle, reason)
+    }
+
     private func loadPlugin(at dir: URL) {
+        let bundle = dir.lastPathComponent
         let manifestURL = dir.appendingPathComponent("manifest.json")
         let mainURL = dir.appendingPathComponent("main.js")
-        guard let data = try? Data(contentsOf: manifestURL),
-              let manifest = try? JSONDecoder().decode(PluginManifest.self, from: data),
-              let scriptData = try? Data(contentsOf: mainURL),
-              let script = String(data: scriptData, encoding: .utf8) else { return }
-        guard let ctx = JSContext() else { return }
+
+        guard let data = try? Data(contentsOf: manifestURL) else {
+            recordFailure(bundle, "missing or unreadable manifest.json"); return
+        }
+        let manifest: PluginManifest
+        do {
+            manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+        } catch {
+            recordFailure(bundle, "invalid manifest.json — \(error.localizedDescription)"); return
+        }
+        guard let scriptData = try? Data(contentsOf: mainURL),
+              let script = String(data: scriptData, encoding: .utf8) else {
+            recordFailure(manifest.id, "missing or unreadable main.js"); return
+        }
+        guard !plugins.contains(where: { $0.manifest.id == manifest.id }) else {
+            recordFailure(manifest.id, "duplicate plugin id — already loaded from another bundle"); return
+        }
+        guard let ctx = JSContext() else {
+            recordFailure(manifest.id, "could not create a JavaScript context"); return
+        }
         let handlers = HandlerBox()
         installBridge(ctx, plugin: manifest, handlers: handlers)
         ctx.evaluateScript(script)
-        if ctx.exception != nil {
-            NSLog("FT plugin '\(manifest.id)' error: \(String(describing: ctx.exception))")
-            return
+        if let ex = ctx.exception {
+            recordFailure(manifest.id, "script error — \(ex)"); return
         }
         plugins.append(LoadedPlugin(manifest: manifest, context: ctx,
                                     directory: dir, handlers: handlers))
@@ -146,21 +172,37 @@ final class PluginHost {
         }
         ft?.setValue(writeFile, forProperty: "writeFile")
 
-        // ft.run(["arg", ...]) -> stdout
+        // ft.run(["cmd", "arg", ...]) -> stdout. An absolute path runs directly;
+        // a bare command name is resolved through PATH via /usr/bin/env, so
+        // ft.run(["ls", "-la"]) works like you'd expect.
         let run: @convention(block) ([String]) -> String? = { args in
-            guard !args.isEmpty else { return nil }
+            guard let cmd = args.first, !cmd.isEmpty else { return nil }
             let p = Process()
-            p.launchPath = args[0]
-            p.arguments = Array(args.dropFirst())
+            if cmd.hasPrefix("/") {
+                p.executableURL = URL(fileURLWithPath: cmd)
+                p.arguments = Array(args.dropFirst())
+            } else {
+                p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                p.arguments = args   // env resolves cmd against PATH
+            }
             let pipe = Pipe()
             p.standardOutput = pipe
             p.standardError = FileHandle.nullDevice  // unused; nullDevice avoids a full-pipe deadlock
-            do { try p.run() } catch { return nil }
+            do { try p.run() } catch {
+                NSLog("FT plugin '%@' ft.run failed: %@", plugin.name, error.localizedDescription)
+                return nil
+            }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             p.waitUntilExit()
             return String(data: data, encoding: .utf8)
         }
         ft?.setValue(run, forProperty: "run")
+
+        // ft.log("text") — write to the system log for debugging a plugin.
+        let log: @convention(block) (String) -> Void = { msg in
+            NSLog("FT plugin '%@' log: %@", plugin.name, msg)
+        }
+        ft?.setValue(log, forProperty: "log")
 
         // ft.currentURL() -> string
         let currentURL: @convention(block) () -> String? = {
@@ -184,10 +226,79 @@ final class PluginHost {
         for p in plugins {
             guard let handler = p.handlers.map[id], !handler.isUndefined else { continue }
             let urls = wc.testActivePane?.selectedURLs().map { $0.path } ?? []
+            p.context.exception = nil   // clear any stale exception before the call
             handler.call(withArguments: [urls])
+            // A handler that throws used to fail silently. Surface it in the
+            // status bar and the log, and clear it so it can't leak into the
+            // next plugin call on this context.
+            if let ex = p.context.exception {
+                p.context.exception = nil
+                NSLog("FT plugin action '%@' threw: %@", id, "\(ex)")
+                wc.testActivePane?.flashStatus("\(p.manifest.name): \(ex)")
+            }
             return
         }
     }
+
+    // MARK: Example plugin
+
+    /// Write a small, working example plugin into the Plugins folder so users
+    /// have a real bundle to learn from. Returns the bundle URL, or nil if it
+    /// couldn't be written. Does not overwrite an existing copy.
+    @discardableResult
+    static func installExample() -> URL? {
+        let bundle = pluginsDirectory.appendingPathComponent("word-count.ftplugin")
+        let fm = FileManager.default
+        guard !fm.fileExists(atPath: bundle.path) else { return bundle }
+        do {
+            try fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+            try exampleManifest.write(to: bundle.appendingPathComponent("manifest.json"),
+                                      atomically: true, encoding: .utf8)
+            try exampleScript.write(to: bundle.appendingPathComponent("main.js"),
+                                    atomically: true, encoding: .utf8)
+            return bundle
+        } catch {
+            NSLog("FT: failed to install example plugin: %@", error.localizedDescription)
+            return nil
+        }
+    }
+
+    private static let exampleManifest = """
+    {
+      "id": "dev.rascal.word-count",
+      "name": "Word Count",
+      "version": "1.0",
+      "actions": [
+        { "id": "word-count.count", "title": "Count Words in Selection" }
+      ]
+    }
+    """
+
+    private static let exampleScript = """
+    // Word Count — a starter Rascal plugin.
+    // Select one or more text files, then run "Count Words in Selection"
+    // from the Command Palette (⌘⇧P).
+    //
+    // The `ft` bridge gives you: onAction, notify, log, readFile, writeFile,
+    // run, currentURL, selectedURLs.
+
+    ft.onAction('word-count.count', function (urls) {
+      if (!urls || urls.length === 0) {
+        ft.notify('Select a file first.');
+        return;
+      }
+      var files = 0, words = 0, lines = 0;
+      urls.forEach(function (path) {
+        var text = ft.readFile(path);
+        if (text === null) return;        // skip unreadable/binary files
+        files += 1;
+        lines += text.split('\\n').length;
+        var trimmed = text.trim();
+        if (trimmed.length) words += trimmed.split(/\\s+/).length;
+      });
+      ft.notify(words + ' words, ' + lines + ' lines across ' + files + ' file(s)');
+    });
+    """
 }
 
 extension ActionRegistry {

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -2278,6 +2278,46 @@ final class TestRunner {
         assert("plugin action surfaces in command palette",
                echoInPalette, "plugin action not in palette — user can't trigger it")
 
+        // --- T59c: a malformed manifest is RECORDED as a failure, not silently
+        // dropped (so the user can be told why a plugin didn't appear).
+        let badDir = sandbox.appendingPathComponent("broken.ftplugin")
+        try? FileManager.default.createDirectory(at: badDir, withIntermediateDirectories: true)
+        try? "{ this is not valid json".write(to: badDir.appendingPathComponent("manifest.json"),
+                                              atomically: true, encoding: .utf8)
+        let failBefore = PluginHost.shared.failures.count
+        PluginHost.shared.testLoad(at: badDir)
+        assert("malformed plugin manifest is recorded as a load failure",
+               PluginHost.shared.failures.count > failBefore,
+               "silent drop — user gets no feedback")
+
+        // --- T59d: a handler that throws at runtime is surfaced and the
+        // exception is cleared, so it can't leak into the next plugin call.
+        let throwDir = sandbox.appendingPathComponent("thrower.ftplugin")
+        try? FileManager.default.createDirectory(at: throwDir, withIntermediateDirectories: true)
+        try? "{\"id\":\"test.throw\",\"name\":\"Thrower\",\"actions\":[{\"id\":\"test.throw.go\",\"title\":\"Throw\"}]}"
+            .write(to: throwDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+        try? "ft.onAction('test.throw.go', function(){ throw new Error('boom'); });"
+            .write(to: throwDir.appendingPathComponent("main.js"), atomically: true, encoding: .utf8)
+        PluginHost.shared.testLoad(at: throwDir)
+        PluginHost.shared.fireAction(id: "test.throw.go", wc: wc)
+        let thrower = PluginHost.shared.plugins.first { $0.manifest.id == "test.throw" }
+        assert("throwing plugin handler leaves no lingering exception",
+               thrower != nil && thrower!.context.exception == nil,
+               "exception not cleared after handler threw")
+
+        // --- T59e: the shipped example plugin is valid and actually loads.
+        // Only exercised when we freshly create it, and cleaned up afterward so
+        // a real user's Plugins folder is never polluted by the test run.
+        let exampleExisted = FileManager.default.fileExists(
+            atPath: PluginHost.pluginsDirectory.appendingPathComponent("word-count.ftplugin").path)
+        if !exampleExisted, let exURL = PluginHost.installExample() {
+            PluginHost.shared.testLoad(at: exURL)
+            assert("example plugin loads and registers its action",
+                   ActionRegistry.action(id: "word-count.count") != nil,
+                   "example plugin failed to load")
+            try? FileManager.default.removeItem(at: exURL)
+        }
+
         // --- T60: construct every sheet/window controller (catches layout +
         // constraint crashes that off-screen menu tests miss). We force
         // `loadView`/`window` so the entire view hierarchy is built.

--- a/Sources/FinderTwo/UI/SettingsPanes.swift
+++ b/Sources/FinderTwo/UI/SettingsPanes.swift
@@ -530,6 +530,10 @@ final class AdvancedPane: SettingsPane {
         reloadBtn.bezelStyle = .rounded
         addRow("", reloadBtn)
 
+        let exampleBtn = NSButton(title: "Install Example Plugin", target: self, action: #selector(installExamplePlugin))
+        exampleBtn.bezelStyle = .rounded
+        addRow("", exampleBtn)
+
         let resetBtn = NSButton(title: "Reset General & Appearance", target: self, action: #selector(resetSettings))
         resetBtn.bezelStyle = .rounded
         addRow("Settings:", resetBtn)
@@ -553,10 +557,44 @@ final class AdvancedPane: SettingsPane {
         // Rebuild the menu so new plugin actions get menu items + key equivalents
         // and removed ones drop out (AppDelegate rebuilds on this notification).
         NotificationCenter.default.post(name: ActionRegistry.shortcutsDidChange, object: nil)
-        if let w = view.window {
-            let a = NSAlert()
-            a.messageText = "Plugins reloaded"
-            a.informativeText = "\(PluginHost.shared.plugins.count) plugin(s) loaded."
+        guard let w = view.window else { return }
+        let host = PluginHost.shared
+        let a = NSAlert()
+        a.messageText = "Plugins reloaded"
+        var info = "\(host.plugins.count) plugin(s) loaded."
+        if !host.failures.isEmpty {
+            a.alertStyle = .warning
+            let lines = host.failures.map { "• \($0.bundle): \($0.reason)" }.joined(separator: "\n")
+            info += "\n\n\(host.failures.count) failed to load:\n\(lines)"
+        }
+        a.informativeText = info
+        a.beginSheetModal(for: w, completionHandler: { _ in })
+    }
+
+    @objc private func installExamplePlugin() {
+        let existed = FileManager.default.fileExists(
+            atPath: PluginHost.pluginsDirectory.appendingPathComponent("word-count.ftplugin").path)
+        let url = PluginHost.installExample()
+        PluginHost.shared.loadAll()
+        NotificationCenter.default.post(name: ActionRegistry.shortcutsDidChange, object: nil)
+        guard let w = view.window else { return }
+        let a = NSAlert()
+        if let url {
+            a.messageText = existed ? "Example plugin already installed" : "Example plugin installed"
+            a.informativeText = existed
+                ? "“Word Count” is already in your Plugins folder. Select text files and run “Count Words in Selection” from the Command Palette (⌘⇧P)."
+                : "Added “Word Count” to your Plugins folder. Select one or more text files, then run “Count Words in Selection” from the Command Palette (⌘⇧P). Edit its main.js to learn the API."
+            a.addButton(withTitle: "OK")
+            a.addButton(withTitle: "Reveal in Finder")
+            a.beginSheetModal(for: w) { resp in
+                if resp == .alertSecondButtonReturn {
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
+                }
+            }
+        } else {
+            a.alertStyle = .warning
+            a.messageText = "Couldn’t install the example plugin"
+            a.informativeText = "Check that the Plugins folder is writable."
             a.beginSheetModal(for: w, completionHandler: { _ in })
         }
     }


### PR DESCRIPTION
Makes the JavaScript plugin feature actually usable instead of failing silently.

## Problems fixed
- **Silent load failures** — a malformed `manifest.json` or missing `main.js` just `return`ed with no feedback. Now each failure is recorded with a specific reason (invalid manifest, missing main.js, duplicate id, JS error), logged, and shown in the Reload Plugins summary.
- **Silent runtime failures** — `fireAction` never checked `context.exception` after calling a handler. A handler that threw did nothing and left a stale exception on the context. Now the exception is cleared before the call and, if thrown, flashed in the status bar + logged, and cleared so it can't leak into the next plugin call.
- **`ft.run` footgun** — required an absolute path, so `ft.run(["ls"])` failed silently. Bare commands now resolve through PATH via `/usr/bin/env`; absolute paths still run directly. Added `ft.log()` for debugging.

## Discoverability
- New **Install Example Plugin** button (Settings → Advanced) writes a working `word-count.ftplugin` and offers to reveal it — an editable starting point.
- **Reload Plugins** now reports which bundles failed and why, not just the success count.

## Tests
3 new regression guards (553/553 green): malformed manifest is recorded (not dropped), a throwing handler leaves no lingering exception, and the shipped example plugin loads. The example test cleans up so it never pollutes a real Plugins folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)