### PR TITLE
UX & feel: drawer slides, vim indicator, overlay fades, and a network-mount freeze fix

### DIFF
--- a/Sources/FinderTwo/Input/VimMode.swift
+++ b/Sources/FinderTwo/Input/VimMode.swift
@@ -24,12 +24,33 @@ import AppKit
 final class VimMode {
     static let shared = VimMode()
 
+    /// Posted whenever the visible vim state changes (enabled, mode, pending
+    /// operator, or count) so the status bar can show a current indicator.
+    static let stateDidChange = Notification.Name("FinderTwo.vimStateDidChange")
+
     enum Mode { case normal, visual }
     private(set) var enabled: Bool = UserDefaults.standard.bool(forKey: "FinderTwo.vimEnabled")
     private(set) var mode: Mode = .normal
     private var pending: String = ""    // pending keystrokes (e.g. "g" awaiting "g" or "t")
     private var count: Int = 0          // numeric prefix (e.g. 5j)
     private var visualAnchor: Int?       // row anchor when in visual mode
+
+    /// Compact indicator for the status bar: "" when vim is off, otherwise the
+    /// mode plus any in-progress count/operator (e.g. "NORMAL", "VISUAL",
+    /// "NORMAL  3d"). Mirrors what vim shows in its bottom-right.
+    var statusText: String {
+        guard enabled else { return "" }
+        var s = (mode == .visual) ? "VISUAL" : "NORMAL"
+        var pend = ""
+        if count > 0 { pend += "\(count)" }
+        pend += (pending == "ctrl-b") ? "^b" : pending
+        if !pend.isEmpty { s += "  " + pend }
+        return s
+    }
+
+    private func postState() {
+        NotificationCenter.default.post(name: VimMode.stateDidChange, object: nil)
+    }
 
     func setEnabled(_ on: Bool) {
         enabled = on
@@ -42,12 +63,14 @@ final class VimMode {
         count = 0
         mode = .normal
         visualAnchor = nil
+        postState()
     }
 
     /// Returns true if the event was consumed; false to let the table handle it.
     @discardableResult
     func handle(event: NSEvent, in pane: PaneController, fileList: FileListController) -> Bool {
         guard enabled else { return false }
+        defer { postState() }   // refresh the status-bar indicator after any state change
         let mods = event.modifierFlags.intersection([.command, .option, .control])
         let isCtrlB = mods == .control && event.charactersIgnoringModifiers == "b"
         if !mods.isEmpty && !isCtrlB && pending != "ctrl-b" { return false }

--- a/Sources/FinderTwo/Model/DirectoryModel.swift
+++ b/Sources/FinderTwo/Model/DirectoryModel.swift
@@ -108,8 +108,20 @@ final class DirectoryModel {
             }
             return
         }
-        reload(sync: true)
+        // A slow or wedged network mount would freeze the main thread if we
+        // scanned it synchronously. Local volumes load sync (instant, no
+        // flicker); network volumes load async so navigation never beachballs —
+        // the path bar updates immediately and the list fills in when the scan
+        // returns (directoryModelDidUpdate refreshes every view).
+        reload(sync: DirectoryModel.isLocalVolume(url))
         startWatcher()
+    }
+
+    /// Whether `url` lives on a local volume. Network mounts (SMB / AFP / NFS /
+    /// WebDAV) report false. Defaults to true when the flag can't be read, so an
+    /// ordinary local path keeps its snappy synchronous load.
+    static func isLocalVolume(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.volumeIsLocalKey]).volumeIsLocal) ?? true
     }
 
     /// Trigger a reload. By default async on a background queue. Set sync=true

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -604,8 +604,13 @@ final class TestRunner {
         let beforeVim = VimMode.shared.enabled
         VimMode.shared.setEnabled(true)
         assert("vim mode enabled", VimMode.shared.enabled, "not enabled")
+        // Status-bar indicator reflects state: shows NORMAL when on, "" when off.
+        assert("vim status indicator shows NORMAL when enabled",
+               VimMode.shared.statusText == "NORMAL", "got '\(VimMode.shared.statusText)'")
         VimMode.shared.setEnabled(false)
         assert("vim mode disabled", !VimMode.shared.enabled, "still enabled")
+        assert("vim status indicator is empty when disabled",
+               VimMode.shared.statusText.isEmpty, "got '\(VimMode.shared.statusText)'")
         VimMode.shared.setEnabled(beforeVim)
 
         // --- T27: Workspaces save + open ---

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -42,6 +42,12 @@ final class TestRunner {
         assert("subdir contents",
                pane.testCurrentItems.contains(where: { $0.name == "nested_file.txt" }),
                "items=\(pane.testCurrentItems.map { $0.name })")
+        // P1 guard: local volumes are detected as local, so navigation loads
+        // synchronously (instant). Network mounts would load async to avoid
+        // freezing the main thread on a slow/wedged share.
+        assert("sandbox is detected as a local volume (sync navigation)",
+               DirectoryModel.isLocalVolume(subURL),
+               "local sandbox path misreported as non-local")
 
         // --- T3: goUp returns to sandbox ---
         pane.goUp()

--- a/Sources/FinderTwo/UI/CommandPaletteController.swift
+++ b/Sources/FinderTwo/UI/CommandPaletteController.swift
@@ -79,8 +79,7 @@ final class CommandPaletteController: NSWindowController, NSTextFieldDelegate, N
         PresentedControllers.existing(SearchSheetController.self)?.close()
         let palette = CommandPaletteController(target: wc)
         PresentedControllers.retain(palette)
-        if let w = palette.window { OverlayUI.center(w, over: wc.window) }
-        palette.window?.makeKeyAndOrderFront(nil)
+        if let w = palette.window { OverlayUI.present(w, over: wc.window) }
     }
 
     init(target: BrowserWindowController) {

--- a/Sources/FinderTwo/UI/OverlayUI.swift
+++ b/Sources/FinderTwo/UI/OverlayUI.swift
@@ -45,12 +45,6 @@ enum OverlayUI {
         return p
     }
 
-    /// Position a floating finder over its parent window instead of the screen,
-    /// so the palette / Find Files / Search Contents appear on the window the
-    /// user is actually using (matters most with multiple windows or displays).
-    /// Sits a little above the parent's vertical centre — the conventional spot
-    /// for a launcher overlay — and stays fully on the parent's screen. Falls
-    /// back to screen-centring when there's no parent window.
     /// Center the overlay over its parent and fade it in, instead of a bare
     /// makeKeyAndOrderFront, so the finders get a quick, soft entrance.
     static func present(_ panel: NSWindow, over parent: NSWindow?) {
@@ -63,6 +57,12 @@ enum OverlayUI {
         }
     }
 
+    /// Position a floating finder over its parent window instead of the screen,
+    /// so the palette / Find Files / Search Contents appear on the window the
+    /// user is actually using (matters most with multiple windows or displays).
+    /// Sits a little above the parent's vertical centre — the conventional spot
+    /// for a launcher overlay — and stays fully on the parent's screen. Falls
+    /// back to screen-centring when there's no parent window.
     static func center(_ panel: NSWindow, over parent: NSWindow?) {
         guard let parent, let screen = parent.screen ?? NSScreen.main else {
             panel.center(); return

--- a/Sources/FinderTwo/UI/OverlayUI.swift
+++ b/Sources/FinderTwo/UI/OverlayUI.swift
@@ -51,6 +51,18 @@ enum OverlayUI {
     /// Sits a little above the parent's vertical centre — the conventional spot
     /// for a launcher overlay — and stays fully on the parent's screen. Falls
     /// back to screen-centring when there's no parent window.
+    /// Center the overlay over its parent and fade it in, instead of a bare
+    /// makeKeyAndOrderFront, so the finders get a quick, soft entrance.
+    static func present(_ panel: NSWindow, over parent: NSWindow?) {
+        center(panel, over: parent)
+        panel.alphaValue = 0
+        panel.makeKeyAndOrderFront(nil)
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.12
+            panel.animator().alphaValue = 1
+        }
+    }
+
     static func center(_ panel: NSWindow, over parent: NSWindow?) {
         guard let parent, let screen = parent.screen ?? NSScreen.main else {
             panel.center(); return

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -87,43 +87,74 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
         }
     }
 
+    /// Slide a drawer open/closed by animating its size constraint (the drawers
+    /// pin their width/height to 0 when closed), instead of snapping. `onOpen`
+    /// runs immediately with the drawer shown; `afterOpen` runs once the open
+    /// slide finishes (e.g. to load content at full size); `afterClose` runs
+    /// after the close slide, only if the drawer wasn't reopened meanwhile.
+    private func animateDrawer(_ drawer: NSView, _ constraint: NSLayoutConstraint,
+                               open: Bool, size: CGFloat,
+                               onOpen: (() -> Void)? = nil,
+                               afterOpen: (() -> Void)? = nil,
+                               afterClose: (() -> Void)? = nil) {
+        if open {
+            drawer.isHidden = false
+            onOpen?()
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = 0.18
+                ctx.allowsImplicitAnimation = true
+                constraint.constant = size
+                self.view.layoutSubtreeIfNeeded()
+            }, completionHandler: afterOpen)
+        } else {
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = 0.16
+                ctx.allowsImplicitAnimation = true
+                constraint.constant = 0
+                self.view.layoutSubtreeIfNeeded()
+            }, completionHandler: { [weak drawer] in
+                // Skip teardown if a quick re-open reset the constant.
+                guard constraint.constant == 0 else { return }
+                drawer?.isHidden = true
+                afterClose?()
+            })
+        }
+    }
+
     /// Toggle the bottom terminal drawer.
     func toggleTerminalDrawer() {
         terminalVisible.toggle()
         if terminalVisible {
-            terminalView.isHidden = false
-            terminalView.cwd = activeTab.currentURL
-            terminalHeightConstraint.constant = 220
+            animateDrawer(terminalView, terminalHeightConstraint, open: true, size: 220,
+                          onOpen: { [weak self] in self?.terminalView.cwd = self?.activeTab.currentURL ?? URL(fileURLWithPath: NSHomeDirectory()) })
             DispatchQueue.main.async { [weak self] in self?.terminalView.focusInput() }
         } else {
-            terminalHeightConstraint.constant = 0
-            terminalView.isHidden = true
-            terminalView.terminateRunning()   // don't keep a child running off-screen
+            animateDrawer(terminalView, terminalHeightConstraint, open: false, size: 220,
+                          afterClose: { [weak self] in self?.terminalView.terminateRunning() })
         }
     }
 
     func toggleGitDiffDrawer() {
         gitDiffVisible.toggle()
         if gitDiffVisible {
-            gitDiffView.isHidden = false
-            gitDiffWidthConstraint.constant = 400
-            if let first = selectedURLs().first,
-               (try? first.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) != true {
-                gitDiffView.fileURL = first
-            } else {
-                gitDiffView.fileURL = nil
-            }
+            animateDrawer(gitDiffView, gitDiffWidthConstraint, open: true, size: 400, onOpen: { [weak self] in
+                guard let self else { return }
+                if let first = self.selectedURLs().first,
+                   (try? first.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) != true {
+                    self.gitDiffView.fileURL = first
+                } else {
+                    self.gitDiffView.fileURL = nil
+                }
+            })
         } else {
-            gitDiffWidthConstraint.constant = 0
-            gitDiffView.isHidden = true
+            animateDrawer(gitDiffView, gitDiffWidthConstraint, open: false, size: 400)
         }
     }
 
     func showGitDiffDrawer(for url: URL) {
         if !gitDiffVisible {
             gitDiffVisible = true
-            gitDiffView.isHidden = false
-            gitDiffWidthConstraint.constant = 400
+            animateDrawer(gitDiffView, gitDiffWidthConstraint, open: true, size: 400)
         }
         gitDiffView.fileURL = url
     }
@@ -132,25 +163,27 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     func toggleNotesDrawer() {
         notesVisible.toggle()
         if notesVisible {
-            notesView.isHidden = false
-            notesView.folderURL = activeTab.currentURL
-            notesWidthConstraint.constant = 280
+            animateDrawer(notesView, notesWidthConstraint, open: true, size: 280,
+                          onOpen: { [weak self] in self?.notesView.folderURL = self?.activeTab.currentURL })
         } else {
             notesView.saveNow()
-            notesWidthConstraint.constant = 0
-            notesView.isHidden = true
+            animateDrawer(notesView, notesWidthConstraint, open: false, size: 280)
         }
     }
 
     func togglePreviewDrawer() {
         previewVisible.toggle()
-        previewView.isHidden = !previewVisible
-        previewWidthConstraint.constant = previewVisible ? 260 : 0
         if previewVisible {
-            // Lay out the new 260pt width before loading, so QuickLook never renders
-            // a preview into a zero-width view (which crashes — see PreviewDrawerView).
-            view.layoutSubtreeIfNeeded()
-            updatePreviewContent()
+            // Load the preview only once the drawer has slid to full width —
+            // QuickLook needs a non-zero frame (PreviewDrawerView guards this,
+            // but loading at full size avoids a blank first paint).
+            animateDrawer(previewView, previewWidthConstraint, open: true, size: 260,
+                          afterOpen: { [weak self] in
+                              guard let self, self.previewVisible else { return }
+                              self.updatePreviewContent()
+                          })
+        } else {
+            animateDrawer(previewView, previewWidthConstraint, open: false, size: 260)
         }
     }
 

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -1025,9 +1025,32 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
             } else {
                 emptyState.configureEmpty()
             }
-            emptyState.isHidden = false
+            setEmptyStateVisible(true)
         } else {
-            emptyState.isHidden = true
+            setEmptyStateVisible(false)
+        }
+    }
+
+    /// Fade the empty-state card in/out, but only on an actual visibility change
+    /// — updateStatus() runs on every recompute and selection change, so we must
+    /// not re-animate while it's already in its target state.
+    private func setEmptyStateVisible(_ visible: Bool) {
+        let currentlyVisible = !emptyState.isHidden && emptyState.alphaValue > 0
+        guard visible != currentlyVisible else { return }
+        if visible {
+            emptyState.alphaValue = 0
+            emptyState.isHidden = false
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.15
+                self.emptyState.animator().alphaValue = 1
+            }
+        } else {
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = 0.12
+                self.emptyState.animator().alphaValue = 0
+            }, completionHandler: { [weak self] in
+                if self?.emptyState.alphaValue == 0 { self?.emptyState.isHidden = true }
+            })
         }
     }
 

--- a/Sources/FinderTwo/UI/SearchSheetController.swift
+++ b/Sources/FinderTwo/UI/SearchSheetController.swift
@@ -48,8 +48,7 @@ final class SearchSheetController: NSWindowController, NSTextFieldDelegate, NSTa
         guard let pane = wc.testActivePane else { return }
         let s = SearchSheetController(target: wc, mode: mode, rootURL: pane.currentURL)
         PresentedControllers.retain(s)
-        if let w = s.window { OverlayUI.center(w, over: wc.window) }
-        s.window?.makeKeyAndOrderFront(nil)
+        if let w = s.window { OverlayUI.present(w, over: wc.window) }
         s.window?.makeFirstResponder(s.searchField)
     }
 

--- a/Sources/FinderTwo/UI/StatusBarView.swift
+++ b/Sources/FinderTwo/UI/StatusBarView.swift
@@ -50,6 +50,9 @@ final class StatusBarView: NSView, ThemeObserving {
 
     private let label = NSTextField(labelWithString: "")
     private let topLine = SeparatorView()
+    /// Trailing vim-mode indicator (e.g. "NORMAL", "VISUAL", "NORMAL 3d"),
+    /// shown only while Vim navigation is enabled.
+    private let vimLabel = NSTextField(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -66,6 +69,14 @@ final class StatusBarView: NSView, ThemeObserving {
             label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 12),
             label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
         ])
+        vimLabel.translatesAutoresizingMaskIntoConstraints = false
+        vimLabel.alignment = .right
+        vimLabel.isHidden = true
+        addSubview(vimLabel)
+        NSLayoutConstraint.activate([
+            vimLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            vimLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
         topLine.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topLine)
         NSLayoutConstraint.activate([
@@ -75,12 +86,25 @@ final class StatusBarView: NSView, ThemeObserving {
             topLine.heightAnchor.constraint(equalToConstant: 1),
         ])
         subscribeToTheme(self)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshVim),
+                                               name: VimMode.stateDidChange, object: nil)
+        refreshVim()
     }
     required init?(coder: NSCoder) { fatalError() }
+
+    @objc private func refreshVim() {
+        let text = VimMode.shared.statusText
+        vimLabel.isHidden = text.isEmpty
+        vimLabel.attributedStringValue = NSAttributedString(string: text, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 9.5, weight: .semibold),
+            .foregroundColor: ThemeManager.shared.effectiveAccent,
+        ])
+    }
 
     @objc func applyTheme() {
         let t = ThemeManager.shared.current
         layer?.backgroundColor = t.background.cgColor
         setSegments(lastSegments)   // re-render text in the new theme's colors
+        refreshVim()                // recolor the vim badge for the new theme
     }
 }


### PR DESCRIPTION
A batch of UX/feel improvements from a focused audit. All build clean; smoketest 553/553 (added 3 assertions).

## Changes
- **Drawers slide instead of snapping** — the terminal, git-diff, notes, and preview drawers animate their size constraint (~180ms) with guarded teardown; preview content loads at full width.
- **Vim-mode indicator** — the status bar shows a `NORMAL`/`VISUAL` (+ in-progress count/operator like `3d`) accent badge while Vim is enabled. `VimMode` now posts a `stateDidChange` notification and exposes `statusText`.
- **No main-thread freeze on slow network mounts** (the real bug) — `navigate()` scanned the target dir synchronously on the main thread, so entering a slow/wedged SMB/AFP/WebDAV share beachballed the app. Local volumes still load sync (instant, what the tests exercise); network volumes load async — the path bar updates immediately and the list fills in when the scan returns. Detected via `.volumeIsLocalKey`.
- **Command palette & search overlays fade in** via `OverlayUI.present()` (centers over the parent window + 120ms fade).
- **Empty-state card fades in/out** while filtering, guarded so frequent `updateStatus()` calls don't re-animate.

## Testing
- Automated: 553/553 smoketest, incl. new guards for the vim indicator and local-volume detection.
- Headed: verified single-window launch, palette centered+faded, terminal drawer slide open/close, and the empty-state fade in/out by driving the running app.

## Notes
- The **network-mount path of the freeze fix is unverified against a real slow share** (none available here); the local path is tested and it reuses the existing async-refresh path the directory watcher already uses. Worth a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)