### PR TITLE
Default file manager: open folders in Rascal instead of Finder

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -47,6 +47,7 @@
             <array>
                 <string>public.folder</string>
                 <string>public.directory</string>
+                <string>public.volume</string>
             </array>
         </dict>
     </array>

--- a/Sources/FinderTwo/Model/DefaultFileManager.swift
+++ b/Sources/FinderTwo/Model/DefaultFileManager.swift
@@ -1,0 +1,59 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Makes Rascal the system handler for folders and drives, so opening a folder, a
+/// volume, or a "Reveal in Finder" from another app routes to Rascal instead of
+/// Finder.
+///
+/// What this can and can't do: macOS keeps Finder running for the desktop and for
+/// mounting drives, and those can't be replaced — this is the same ceiling every
+/// third-party file manager (Bloom, QSpace, ForkLift) hits. What IS achievable is
+/// owning the *open-folder* role via Launch Services, which is what this does.
+/// Because Rascal isn't sandboxed, it can set the handler directly through
+/// `NSWorkspace` — no Terminal commands (the App Store builds of other managers
+/// need them because the sandbox forbids this call).
+enum DefaultFileManager {
+    /// The content types a file manager should own: folders, generic directories,
+    /// and mounted volumes. `public.folder` carries most folder opens; adding
+    /// `public.volume` routes drives too. All three are declared in Info.plist, so
+    /// Launch Services accepts Rascal as a candidate handler.
+    private static let types: [UTType] = [.folder, .directory, .volume]
+
+    private static var bundleID: String { Bundle.main.bundleIdentifier ?? "dev.chang.FinderTwo" }
+
+    /// Is Rascal the current default handler for folders?
+    static var isDefault: Bool {
+        guard let url = NSWorkspace.shared.urlForApplication(toOpen: .folder),
+            let id = Bundle(url: url)?.bundleIdentifier
+        else { return false }
+        return id == bundleID
+    }
+
+    /// Point the folder/volume handlers at the running Rascal bundle. Calls back on
+    /// the main queue with the first error, or nil on success.
+    static func makeDefault(completion: @escaping (Error?) -> Void) {
+        apply(appURL: Bundle.main.bundleURL, completion: completion)
+    }
+
+    /// Hand the folder/volume handlers back to Finder.
+    static func restoreFinder(completion: @escaping (Error?) -> Void) {
+        guard let finder = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.finder") else {
+            completion(nil)
+            return
+        }
+        apply(appURL: finder, completion: completion)
+    }
+
+    private static func apply(appURL: URL, completion: @escaping (Error?) -> Void) {
+        let group = DispatchGroup()
+        var firstError: Error?
+        for type in types {
+            group.enter()
+            NSWorkspace.shared.setDefaultApplication(at: appURL, toOpen: type) { error in
+                if let error, firstError == nil { firstError = error }
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) { completion(firstError) }
+    }
+}

--- a/Sources/FinderTwo/Model/DefaultFileManager.swift
+++ b/Sources/FinderTwo/Model/DefaultFileManager.swift
@@ -45,15 +45,38 @@ enum DefaultFileManager {
     }
 
     private static func apply(appURL: URL, completion: @escaping (Error?) -> Void) {
-        let group = DispatchGroup()
-        var firstError: Error?
-        for type in types {
-            group.enter()
-            NSWorkspace.shared.setDefaultApplication(at: appURL, toOpen: type) { error in
-                if let error, firstError == nil { firstError = error }
-                group.leave()
-            }
+        // One type at a time. Each setDefaultApplication can raise its own user
+        // consent prompt; firing all three concurrently makes the prompts collide
+        // and the losers fail immediately with a generic "file couldn't be
+        // opened" error (and Launch Services then caches that refusal). Chaining
+        // them lets each prompt appear and resolve in turn. Verified headed in a
+        // macOS 26 VM: concurrent → instant failure, serialized → three clean
+        // prompts.
+        applyNext(appURL: appURL, remaining: types, firstError: nil, completion: completion)
+    }
+
+    private static func applyNext(appURL: URL, remaining: [UTType], firstError: Error?,
+                                  completion: @escaping (Error?) -> Void) {
+        guard let type = remaining.first else {
+            DispatchQueue.main.async { completion(firstError) }
+            return
         }
-        group.notify(queue: .main) { completion(firstError) }
+        NSWorkspace.shared.setDefaultApplication(at: appURL, toOpen: type) { error in
+            var effectiveError = error
+            if let nsError = error as NSError?,
+                (nsError.userInfo[NSUnderlyingErrorKey] as? NSError)?.code == -50 {
+                // macOS 26's NSWorkspace API refuses folder-ish UTTypes with
+                // paramErr (-50); the legacy Launch Services call still binds
+                // them (verified headed in a macOS 26 VM — same bundle, same
+                // type: NSWorkspace fails where LSSetDefaultRoleHandler succeeds).
+                if let id = Bundle(url: appURL)?.bundleIdentifier {
+                    let status = LSSetDefaultRoleHandlerForContentType(
+                        type.identifier as CFString, .all, id as CFString)
+                    if status == noErr { effectiveError = nil }
+                }
+            }
+            applyNext(appURL: appURL, remaining: Array(remaining.dropFirst()),
+                      firstError: firstError ?? effectiveError, completion: completion)
+        }
     }
 }

--- a/Sources/FinderTwo/UI/SettingsPanes.swift
+++ b/Sources/FinderTwo/UI/SettingsPanes.swift
@@ -483,7 +483,29 @@ final class DeveloperPane: SettingsPane {
 // MARK: - Advanced
 
 final class AdvancedPane: SettingsPane {
+    private var dfmStatus: NSTextField?
+    private var dfmButton: NSButton?
+
     override func build() {
+        // Default file manager — own the open-folder role so folders, drives, and
+        // "reveal" actions from other apps open in Rascal instead of Finder.
+        let dfmBtn = NSButton(title: "", target: self, action: #selector(toggleDefaultFileManager))
+        dfmBtn.bezelStyle = .rounded
+        let dfmStat = NSTextField(labelWithString: "")
+        dfmStat.font = NSFont.systemFont(ofSize: 11)
+        dfmStat.textColor = .secondaryLabelColor
+        dfmButton = dfmBtn
+        dfmStatus = dfmStat
+        refreshDefaultFileManagerUI()
+        addRow("Default file manager:", dfmBtn)
+        addRow("", dfmStat)
+        let dfmHint = NSTextField(wrappingLabelWithString:
+            "Opens folders, drives, and 'reveal' actions from other apps in Rascal instead of Finder. macOS still keeps Finder for the desktop and for mounting drives — that part can't be replaced.")
+        dfmHint.font = NSFont.systemFont(ofSize: 11)
+        dfmHint.textColor = .tertiaryLabelColor
+        dfmHint.preferredMaxLayoutWidth = 380
+        addRow("", dfmHint)
+
         let spring = NSButton(checkboxWithTitle: "Spring-loaded folders (open on drag-hover)",
                               target: self, action: #selector(springChanged(_:)))
         spring.state = Settings.springLoadedFolders ? .on : .off
@@ -542,5 +564,29 @@ final class AdvancedPane: SettingsPane {
             SettingsController.show(selecting: .advanced)
             _ = win
         }
+    }
+
+    @objc private func toggleDefaultFileManager() {
+        let done: (Error?) -> Void = { [weak self] error in
+            self?.refreshDefaultFileManagerUI()
+            guard let error else { return }
+            let alert = NSAlert()
+            alert.messageText = "Couldn't change the default file manager"
+            alert.informativeText = error.localizedDescription
+            alert.runModal()
+        }
+        if DefaultFileManager.isDefault {
+            DefaultFileManager.restoreFinder(completion: done)
+        } else {
+            DefaultFileManager.makeDefault(completion: done)
+        }
+    }
+
+    private func refreshDefaultFileManagerUI() {
+        let isDefault = DefaultFileManager.isDefault
+        dfmButton?.title = isDefault ? "Restore Finder" : "Make Rascal the Default"
+        dfmStatus?.stringValue = isDefault
+            ? "Rascal is the default — folders open here."
+            : "Finder is currently the default."
     }
 }


### PR DESCRIPTION
## What

A **Settings ▸ Advanced** control to make Rascal the default file manager: folders, drives, and "Reveal in Finder" from other apps open in Rascal instead of Finder. Click again to restore Finder. A live status line shows which app currently owns the role.

## How

- New `DefaultFileManager` helper sets/restores the Launch Services default handler for `public.folder`, `public.directory`, and `public.volume` via `NSWorkspace.setDefaultApplication(at:toOpen:)` — the same API already used for "Open With ▸ Change All". Because Rascal isn't sandboxed, it sets this directly with no Terminal `defaults write` workaround (which the Mac App Store builds of other managers require).
- `Info.plist` now declares `public.volume` alongside the existing folder/directory document types.
- Folder routing already worked via `application(_:open:)`, which opens any handed-in folder URL in a new window.

## Limitation (by design)

macOS keeps Finder for the desktop and for mounting drives — that part can't be replaced by any app. This PR claims the achievable piece: the **open-folder role**, which is exactly what Bloom, QSpace Pro, and ForkLift do.

## Testing

- `./build.sh debug` — clean
- `./smoketest.sh` — 549 passed, 0 failed
- `./guitest.sh` — 0 failures
- Read-only probe confirmed the handler API resolves (folder→Finder, directory→Terminal, volume→Finder before the change); no system default was changed during testing.
