### PR TITLE
Fix: Cmd-N opens additional browser windows

### DIFF
--- a/Sources/FinderTwo/AppDelegate.swift
+++ b/Sources/FinderTwo/AppDelegate.swift
@@ -128,7 +128,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Windows
 
     func openNewBrowserWindow(at url: URL) {
-        let wc = BrowserWindowController(rootURL: url)
+        // Only the first live browser window owns the persisted frame; every
+        // additional window (⌘N, "Open in New Window", move-tab-out) cascades
+        // from it as an independent window. Binding the shared frame autosave
+        // name to all of them made each new window restore the first's exact
+        // frame and open directly on top of it — which read as "⌘N does nothing".
+        let isFirst = windowControllers.isEmpty
+        let wc = BrowserWindowController(rootURL: url, autosaveFrame: isFirst)
         finishOpening(wc)
     }
 

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -2267,7 +2267,56 @@ final class TestRunner {
             assert("command palette Open With test file exists", false, "test file not found")
         }
 
+        // --- T62: ⌘N opens ADDITIONAL, independent browser windows ---
+        // Regression guard for the multi-window bug: invoking the new-window
+        // code path N times must yield N *distinct* browser window controllers,
+        // each with its own active pane. (The bug shared one frame autosave name
+        // across all windows, so additional windows stacked invisibly on the
+        // first — it looked like ⌘N did nothing.)
+        runMultiWindowTests(appDelegate: appDelegate, sandbox: sandbox)
+
         finish()
+    }
+
+    /// Drive the new-window path repeatedly and assert each call produces a
+    /// fresh, independent BrowserWindowController. Runs headless (windows are
+    /// parked far off-screen by AppDelegate.finishOpening), so nothing appears.
+    private func runMultiWindowTests(appDelegate: AppDelegate, sandbox: URL) {
+        // Start from a clean slate so the count is unambiguous.
+        for w in NSApp.windows { w.close() }
+        wait(0.05)
+        let before = appDelegate.testWindowControllers.count
+
+        let n = 3
+        for _ in 0..<n {
+            // Exactly the path ⌘N takes (AppDelegate.newWindow → this).
+            appDelegate.openNewBrowserWindow(at: sandbox)
+            wait(0.05)
+        }
+
+        let controllers = appDelegate.testWindowControllers
+        assert("new-window path opens N additional windows",
+               controllers.count == before + n,
+               "expected \(before + n), got \(controllers.count)")
+
+        // Each must be a distinct controller instance (no single-instance dedupe
+        // collapsing them into one).
+        let recent = Array(controllers.suffix(n))
+        let distinct = Set(recent.map { ObjectIdentifier($0) })
+        assert("each new window is a distinct controller",
+               distinct.count == n,
+               "got \(distinct.count) unique of \(recent.count)")
+
+        // Each window must own its own active pane (independent state).
+        let panes = recent.compactMap { $0.testActivePane }
+        let distinctPanes = Set(panes.map { ObjectIdentifier($0) })
+        assert("each new window has its own pane",
+               panes.count == n && distinctPanes.count == n,
+               "panes=\(panes.count) distinct=\(distinctPanes.count)")
+
+        // Clean up the windows this test opened.
+        for w in NSApp.windows { w.close() }
+        wait(0.05)
     }
 
     /// Build every modal/window controller and force its view to load. A crash

--- a/Sources/FinderTwo/Window/BrowserWindowController.swift
+++ b/Sources/FinderTwo/Window/BrowserWindowController.swift
@@ -57,8 +57,20 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
     private var vimKeyMonitor: Any?
     /// Off-main branch lookups for the window subtitle (reads .git/HEAD).
     private static let gitInfoQueue = DispatchQueue(label: "FinderTwo.windowGitInfo", qos: .utility)
+    /// Anchor for cascading additional windows. AppKit's `cascadeTopLeft` mutates
+    /// the point it's given, so we thread it through every window we open: the
+    /// first window seeds it, each subsequent window steps down-right from it so
+    /// new windows never land exactly on top of an existing one.
+    static var cascadePoint = NSPoint.zero
 
-    init(rootURL: URL) {
+    /// - Parameter autosaveFrame: when true (the single launch window) the
+    ///   window's size/position persists across launches via a shared frame
+    ///   autosave name. Additional windows (⌘N, "Open in New Window", move-tab-
+    ///   out) pass false: binding the SAME autosave name to every window made
+    ///   each new window restore the first window's exact frame and open pixel-
+    ///   for-pixel on top of it — so ⌘N looked like it did nothing. Unsaved
+    ///   windows cascade instead, landing visibly offset and independent.
+    init(rootURL: URL, autosaveFrame: Bool = true) {
         self.sidebarVC = SidebarController()
         self.panesContainer = PanesContainerController(initialURL: rootURL)
 
@@ -109,7 +121,13 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
         // contentViewController assignment nor later column navigation can
         // auto-resize the window.
         let isHeadless = ProcessInfo.processInfo.environment["FT_HEADLESS_TESTING"] == "1"
-        if !isHeadless {
+        if isHeadless {
+            window.setContentSize(NSSize(width: 1100, height: 700))
+        } else if autosaveFrame {
+            // The single launch window: persist its size/position across launches.
+            // Only ONE window may own this autosave name — additional windows
+            // (autosaveFrame == false) must not bind it, or they'd all restore
+            // this same frame and stack on top of each other.
             windowFrameAutosaveName = "FinderTwo.BrowserWindow"
             if !window.setFrameUsingName("FinderTwo.BrowserWindow") {
                 window.setContentSize(NSSize(width: 1100, height: 700))
@@ -124,8 +142,17 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
                     window.setFrame(centered, display: false)
                 }
             }
+            // Seed the cascade anchor from the launch window's top-left so the
+            // first ⌘N steps down-right from wherever this window ended up.
+            BrowserWindowController.cascadePoint = NSPoint(x: window.frame.minX,
+                                                           y: window.frame.maxY)
         } else {
+            // An additional window: give it the default size and cascade it from
+            // the last opened window so it's visibly offset and independent —
+            // never restored onto the launch window's saved frame.
             window.setContentSize(NSSize(width: 1100, height: 700))
+            BrowserWindowController.cascadePoint =
+                window.cascadeTopLeft(from: BrowserWindowController.cascadePoint)
         }
         // Initial size is now set (default or autosaved). From here the window only
         // resizes when the user drags its edge / zooms / goes fullscreen — content


### PR DESCRIPTION
## Root cause

`⌘N` (New Window) appeared to do nothing — users reported Rascal "doesn't support multiple windows."

Every `BrowserWindowController` was constructed with the **same** window frame autosave name and restored from it in `init`:

```swift
windowFrameAutosaveName = "FinderTwo.BrowserWindow"
if !window.setFrameUsingName("FinderTwo.BrowserWindow") { … }
```

AppKit's frame autosave assumes a **unique identity per window**. When `⌘N` created a second window, it restored the *first* window's exact saved frame and opened pixel-for-pixel on top of it. Same size + same origin = the new window perfectly occluded the existing one, so it looked like nothing happened.

This was a latent bug. It only became visible after the earlier commit *"Fix window/overlay behavior: single launch window, centered & single-instance finders"* removed multi-window session restore: before, relaunch reopened several windows (each positioned from snapshot data), so multiple windows were a normal sight. Afterward, the only way to get a second window is `⌘N`, which exposed the shared-autosave-name collision. The new-window code path itself (`AppDelegate.newWindow` → `openNewBrowserWindow` → `BrowserWindowController`) was structurally fine — no single-instance guard was blocking it.

## The fix

- `BrowserWindowController.init` gains an `autosaveFrame: Bool = true` parameter.
- Only the **first** live browser window owns the persisted frame autosave name, so a single window's size/position still survives across launches.
- **Additional** windows (`⌘N`, sidebar "Open in New Window", move-tab-to-new-window) pass `autosaveFrame: false`: they skip the shared autosave name and **cascade** from the previously opened window via `cascadeTopLeft(from:)`, so each lands visibly offset and is fully independent (its own panes/state).
- `AppDelegate.openNewBrowserWindow` decides first-vs-additional from `windowControllers.isEmpty`, so all three new-window entry points are covered.

What the earlier commit legitimately fixed is preserved: single window on cold launch, no duplicate window restoration (`isRestorable = false`), and the single-instance / mutually-exclusive overlay finders (Command Palette, Find Files, Search Contents). Those auxiliary finders stay single-instance; only main browser windows are multi-instance.

Headless mode is unchanged — that branch never bound the autosave name and parks windows far off-screen, so tests/DemoShot are unaffected.

## Headless testing

All three gates green on this branch:

- `./build.sh debug` — compiles clean, no new warnings.
- `./smoketest.sh` — **552 passed, 0 failed** (exit 0), including three new assertions:
  - `new-window path opens N additional windows`
  - `each new window is a distinct controller`
  - `each new window has its own pane`
- `./guitest.sh` — **0 failures** (exit 0); confirms `File → New Window` is still wired to `⌘N` (mods=0).

New regression guard added to `Sources/FinderTwo/Tests/TestRunner.swift` (T62): it drives `openNewBrowserWindow` N times and asserts N distinct controllers, each with its own pane. It runs off-screen like the rest of the harness (windows are parked far off every display, never made key on a real screen).

## What to check headed

Live GUI verification (the headless harness can't observe on-screen window placement):

1. Launch the app — exactly **one** window appears, centered (or at its last-saved position).
2. Press `⌘N` — a **second, independent** window appears, **visibly offset** (cascaded down-right), not stacked exactly on the first.
3. Press `⌘N` a few more times — each adds another distinct window, each cascaded further; navigate them independently (different folders, tabs, panes).
4. Confirm the auxiliary finders are still single-instance: `⌘⇧P` (palette), `⌘F` / `⌘⇧F` (search) toggle rather than stacking, and centre over the active window.
5. Resize/move the single window, quit, relaunch — its size/position persists (single-window autosave still works).
