### PR TITLE
Configurable list-view columns (Tags, Comments, Date Added)

### DIFF
--- a/Sources/FinderTwo/FS/SpotlightMetadata.swift
+++ b/Sources/FinderTwo/FS/SpotlightMetadata.swift
@@ -13,6 +13,12 @@ import CoreServices
 /// pattern.
 enum SpotlightMetadata {
 
+    // MDItemCreateWithURL / MDItemCopyAttribute are in CoreServices' audited
+    // bridging region (CF_IMPLICIT_BRIDGING_ENABLED), so Swift imports them as
+    // ARC-managed CF references — NOT Unmanaged — and ARC already balances the
+    // Create/Copy +1 retain. Do NOT add CFRelease / takeRetainedValue here: it
+    // double-frees the MDItem on every call (a use-after-free crash).
+
     /// The Finder comment for `url`, or empty string if none / unreadable.
     /// Safe to call off the main thread.
     static func finderComment(_ url: URL) -> String {

--- a/Sources/FinderTwo/FS/SpotlightMetadata.swift
+++ b/Sources/FinderTwo/FS/SpotlightMetadata.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreServices
+
+/// Reads Spotlight metadata attributes that aren't on `FileItem` — the Finder
+/// comment (`kMDItemFinderComment`) and the date a file was added to its folder
+/// (`kMDItemDateAdded`) — for the configurable list-view columns.
+///
+/// `MDItemCreateWithURL` does synchronous disk I/O, which can be slow on a large
+/// or networked folder, so the list view fetches these OFF the main thread and
+/// repaints the row when the value lands. This type only does the raw read; the
+/// caching / async dispatch lives in `FileListController` next to the existing
+/// folder-size cache so both share the same "fetch off-main, reload one row"
+/// pattern.
+enum SpotlightMetadata {
+
+    /// The Finder comment for `url`, or empty string if none / unreadable.
+    /// Safe to call off the main thread.
+    static func finderComment(_ url: URL) -> String {
+        guard let item = MDItemCreateWithURL(kCFAllocatorDefault, url as CFURL) else { return "" }
+        return (MDItemCopyAttribute(item, kMDItemFinderComment) as? String) ?? ""
+    }
+
+    /// The date `url` was added to its enclosing folder, or nil if Spotlight has
+    /// no record of it (e.g. a freshly created file, or an unindexed volume).
+    /// Safe to call off the main thread.
+    static func dateAdded(_ url: URL) -> Date? {
+        guard let item = MDItemCreateWithURL(kCFAllocatorDefault, url as CFURL) else { return nil }
+        return MDItemCopyAttribute(item, kMDItemDateAdded) as? Date
+    }
+}

--- a/Sources/FinderTwo/Model/ListColumns.swift
+++ b/Sources/FinderTwo/Model/ListColumns.swift
@@ -1,0 +1,153 @@
+import AppKit
+
+/// The set of columns the list view (`FileListController`) can show, plus the
+/// persistence for which ones the user has chosen. "Commands are data" in spirit:
+/// the column set is a single enum the table, the header context menu, and the
+/// cell renderer all read from, so adding a column is one case here.
+///
+/// `name` is mandatory (it carries the icon + inline rename) and always visible;
+/// the rest are user-toggleable from the column-header right-click menu. Width
+/// and order are persisted by NSTableView's own column autosave; visibility is
+/// persisted here (autosave alone doesn't round-trip a column the user has never
+/// revealed in a given install).
+enum ListColumn: String, CaseIterable {
+    case name
+    case modified       // kMDItemContentModificationDate (FileItem.modified)
+    case created        // kMDItemContentCreationDate (FileItem.created)
+    case size
+    case kind
+    case tags           // Finder color tags (kMDItemUserTags) — via Tags.swift
+    case comments       // Spotlight kMDItemFinderComment
+    case dateAdded      // Spotlight kMDItemDateAdded
+
+    /// Stable column identifier used by NSTableColumn (kept equal to rawValue so
+    /// existing autosaved widths/order for "name"/"modified"/"size"/"kind" survive
+    /// the upgrade).
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .name:      return "Name"
+        case .modified:  return "Date Modified"
+        case .created:   return "Date Created"
+        case .size:      return "Size"
+        case .kind:      return "Kind"
+        case .tags:      return "Tags"
+        case .comments:  return "Comments"
+        case .dateAdded: return "Date Added"
+        }
+    }
+
+    var defaultWidth: CGFloat {
+        switch self {
+        case .name:      return 340
+        case .modified:  return 170
+        case .created:   return 170
+        case .size:      return 90
+        case .kind:      return 130
+        case .tags:      return 120
+        case .comments:  return 200
+        case .dateAdded: return 170
+        }
+    }
+
+    var minWidth: CGFloat {
+        switch self {
+        case .name:      return 120
+        case .size:      return 60
+        case .kind:      return 70
+        case .tags:      return 60
+        case .comments:  return 80
+        default:         return 110
+        }
+    }
+
+    /// The sort key a header click on this column applies, or nil for columns we
+    /// don't sort by (tags / comments have no FileItem-backed ordering).
+    var sortKey: SortKey? {
+        switch self {
+        case .name:      return .name
+        case .modified:  return .dateModified
+        case .created:   return .dateCreated
+        case .size:      return .size
+        case .kind:      return .kind
+        case .tags, .comments, .dateAdded: return nil
+        }
+    }
+
+    var alignment: NSTextAlignment { self == .size ? .right : .left }
+
+    /// Mandatory columns can't be hidden (only Name, today).
+    var isMandatory: Bool { self == .name }
+
+    /// Columns shown when the user has never customized the set — matches the
+    /// historical fixed layout (Name / Date Modified / Size / Kind).
+    static let defaultVisible: [ListColumn] = [.name, .modified, .size, .kind]
+
+    /// Whether a Spotlight `MDItem` lookup is needed to render this column (vs.
+    /// data already on the `FileItem`). Drives the off-main fetch in the list.
+    var needsSpotlight: Bool {
+        switch self {
+        case .comments, .dateAdded: return true
+        default: return false
+        }
+    }
+}
+
+/// Persisted set of visible list columns (global, like Finder's "View Options"
+/// "use as default"). Stored under the `FinderTwo.*` UserDefaults namespace as a
+/// list of column ids. Order/width are handled by NSTableView column autosave.
+enum ListColumnPrefs {
+    // Headless tests use a separate key so the suite never clobbers a real user's
+    // chosen columns (mirrors FolderViewPrefs).
+    private static let storeKey: String =
+        ProcessInfo.processInfo.environment["FT_HEADLESS_TESTING"] == "1"
+            ? "FinderTwo.listColumns.test"
+            : "FinderTwo.listColumns.v1"
+
+    private static let d = UserDefaults.standard
+
+    /// The columns the user wants visible, in canonical `ListColumn.allCases`
+    /// order. Always contains the mandatory columns; falls back to the default
+    /// set when nothing has been saved yet. Unknown/stale ids are dropped.
+    static var visible: [ListColumn] {
+        get {
+            guard let ids = d.array(forKey: storeKey) as? [String] else {
+                return ListColumn.defaultVisible   // never customized
+            }
+            let chosen = Set(ids.compactMap { ListColumn(rawValue: $0) })
+            // A stored value that resolves to NO known column is corrupt — fall
+            // back to defaults rather than blanking the list down to just Name.
+            // (The setter always writes Name, so a legitimate "everything off"
+            // still resolves to at least one known column and is honored.)
+            guard !chosen.isEmpty else { return ListColumn.defaultVisible }
+            return ListColumn.allCases.filter { chosen.contains($0) || $0.isMandatory }
+        }
+        set {
+            // Canonicalize: dedupe, force mandatory columns on, keep enum order.
+            let chosen = Set(newValue)
+            let ids = ListColumn.allCases
+                .filter { chosen.contains($0) || $0.isMandatory }
+                .map { $0.rawValue }
+            d.set(ids, forKey: storeKey)
+        }
+    }
+
+    static func isVisible(_ col: ListColumn) -> Bool {
+        col.isMandatory || visible.contains(col)
+    }
+
+    /// Toggle a column on/off (mandatory columns can't be turned off). Returns
+    /// the resulting visibility so callers can update menu state without a reread.
+    @discardableResult
+    static func toggle(_ col: ListColumn) -> Bool {
+        guard !col.isMandatory else { return true }
+        var set = Set(visible)
+        if set.contains(col) { set.remove(col) } else { set.insert(col) }
+        visible = Array(set)
+        return set.contains(col)
+    }
+
+    /// Forget the saved column set (used by a reset affordance + tests).
+    static func reset() { d.removeObject(forKey: storeKey) }
+}

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -1027,6 +1027,68 @@ final class TestRunner {
         FolderViewPrefs.clearAll()
         assert("clearAll empties the store", FolderViewPrefs.count == 0, "count=\(FolderViewPrefs.count)")
 
+        // --- T-listcols: configurable list-view column model + persistence ---
+        // Runs against the headless test store key (FT_HEADLESS_TESTING=1), so it
+        // never touches the user's real chosen columns.
+        ListColumnPrefs.reset()
+        // The required columns exist and Name is the only mandatory one.
+        assert("Name is a mandatory column", ListColumn.name.isMandatory, "not mandatory")
+        assert("only Name is mandatory",
+               ListColumn.allCases.filter { $0.isMandatory } == [.name],
+               "got \(ListColumn.allCases.filter { $0.isMandatory })")
+        assert("Tags / Comments / Date Added columns exist",
+               ListColumn(rawValue: "tags") == .tags
+                && ListColumn(rawValue: "comments") == .comments
+                && ListColumn(rawValue: "dateAdded") == .dateAdded, "missing a column")
+        // Default (uncustomized) visible set matches the historical fixed layout.
+        assert("default columns = Name/Modified/Size/Kind",
+               ListColumnPrefs.visible == [.name, .modified, .size, .kind],
+               "got \(ListColumnPrefs.visible)")
+        assert("Tags hidden by default", !ListColumnPrefs.isVisible(.tags), "visible")
+        // Tags / Comments have no sort key; the date/size/name columns do.
+        assert("Tags column is not sortable", ListColumn.tags.sortKey == nil, "has sort key")
+        assert("Comments column is not sortable", ListColumn.comments.sortKey == nil, "has sort key")
+        assert("Date Added has no FileItem sort key", ListColumn.dateAdded.sortKey == nil, "has sort key")
+        assert("Name column sorts by name", ListColumn.name.sortKey == .name, "wrong key")
+        assert("Created column sorts by dateCreated", ListColumn.created.sortKey == .dateCreated, "wrong key")
+        // Spotlight-backed columns are flagged for the off-main fetch.
+        assert("Comments needs Spotlight", ListColumn.comments.needsSpotlight, "not flagged")
+        assert("Date Added needs Spotlight", ListColumn.dateAdded.needsSpotlight, "not flagged")
+        assert("Tags does NOT need Spotlight", !ListColumn.tags.needsSpotlight, "wrongly flagged")
+        // Toggle a column on → it persists and reports visible.
+        let tagsNowOn = ListColumnPrefs.toggle(.tags)
+        assert("toggle(.tags) turns it on", tagsNowOn, "still off")
+        assert("toggled column is persisted visible", ListColumnPrefs.isVisible(.tags), "not visible")
+        assert("visible set keeps canonical order",
+               ListColumnPrefs.visible == ListColumn.allCases.filter { ListColumnPrefs.visible.contains($0) },
+               "got \(ListColumnPrefs.visible)")
+        // Toggle it back off.
+        let tagsNowOff = ListColumnPrefs.toggle(.tags)
+        assert("toggle(.tags) again turns it off", !tagsNowOff, "still on")
+        assert("toggled-off column not visible", !ListColumnPrefs.isVisible(.tags), "still visible")
+        // Mandatory column can't be hidden, even by direct toggle or an empty set.
+        assert("toggle(.name) keeps it visible", ListColumnPrefs.toggle(.name), "Name turned off")
+        ListColumnPrefs.visible = []   // explicit "everything off"
+        assert("empty set still shows Name", ListColumnPrefs.isVisible(.name), "Name hidden")
+        assert("empty set collapses to just Name",
+               ListColumnPrefs.visible == [.name], "got \(ListColumnPrefs.visible)")
+        // A corrupt stored value with no usable column id falls back to defaults
+        // rather than blanking the list (the getter's last-resort guard).
+        UserDefaults.standard.set(["bogus", "nonsense"], forKey: "FinderTwo.listColumns.test")
+        assert("corrupt stored columns fall back to defaults",
+               ListColumnPrefs.visible == [.name, .modified, .size, .kind],
+               "got \(ListColumnPrefs.visible)")
+        // Setter canonicalizes (dedupes, forces Name on, enum order).
+        ListColumnPrefs.visible = [.comments, .comments, .kind]
+        assert("setter forces Name on + dedupes + orders",
+               ListColumnPrefs.visible == [.name, .kind, .comments],
+               "got \(ListColumnPrefs.visible)")
+        // reset() restores the default set.
+        ListColumnPrefs.reset()
+        assert("reset restores default columns",
+               ListColumnPrefs.visible == [.name, .modified, .size, .kind],
+               "got \(ListColumnPrefs.visible)")
+
         // --- T-eta: transfer throughput + ETA ---
         let etaOp = TransferOp(id: 1, move: false, plan: [])
         assert("a waiting op has no throughput", etaOp.bytesPerSecond == 0, "got \(etaOp.bytesPerSecond)")
@@ -1680,6 +1742,30 @@ final class TestRunner {
         assert("vim nav in gallery mode is safe", pane.viewMode == .gallery, "mode changed")
         pane.setViewMode(.list)
         assert("setViewMode(.list) honored", pane.viewMode == .list, "got=\(pane.viewMode)")
+
+        // --- T-listcols-live: the real FileListController builds every column and
+        // its header-chooser menu reflects the persisted visible set. ---
+        let listTV = pane.testFileList.tableView
+        let builtIDs = Set(listTV.tableColumns.map { $0.identifier.rawValue })
+        assert("list view builds every ListColumn",
+               builtIDs == Set(ListColumn.allCases.map { $0.id }),
+               "got \(builtIDs.sorted())")
+        // Header context menu offers exactly the toggleable (non-mandatory) cols.
+        if let headerMenu = listTV.headerView?.menu {
+            let menuIDs = Set(headerMenu.items.compactMap { $0.representedObject as? String })
+            assert("header menu lists all toggleable columns",
+                   menuIDs == Set(ListColumn.allCases.filter { !$0.isMandatory }.map { $0.id }),
+                   "got \(menuIDs.sorted())")
+            assert("header menu omits the mandatory Name column",
+                   !menuIDs.contains(ListColumn.name.id), "Name present")
+        } else {
+            assert("list view has a header chooser menu", false, "no menu")
+        }
+        // A hidden-by-default column (Tags) is actually hidden on the live table.
+        if let tagsCol = listTV.tableColumns.first(where: { $0.identifier.rawValue == ListColumn.tags.id }) {
+            assert("Tags column hidden on a fresh list view", tagsCol.isHidden, "visible")
+        } else { assert("Tags column present on the table", false, "missing") }
+        ListColumnPrefs.reset()
 
         // setViewMode(persist:false) must NOT record a per-folder pref (used for
         // the launch-time global default); a normal user change must.

--- a/Sources/FinderTwo/UI/FileListController.swift
+++ b/Sources/FinderTwo/UI/FileListController.swift
@@ -505,6 +505,10 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
     private let spotlightCache: NSCache<NSURL, SpotlightEntry> = {
         let c = NSCache<NSURL, SpotlightEntry>(); c.countLimit = 4096; return c
     }()
+    // Main-thread-confined: read + inserted in spotlightEntry(for:) (called from
+    // tableView(_:viewFor:) on main) and removed inside DispatchQueue.main.async.
+    // The off-main fetch (spotlightQueue.async) never touches this set, so it needs
+    // no lock — adding one would only add main-thread contention.
     private var spotlightInFlight: Set<URL> = []
 
     /// Cached Spotlight metadata for `url`, kicking off an off-main fetch (and

--- a/Sources/FinderTwo/UI/FileListController.swift
+++ b/Sources/FinderTwo/UI/FileListController.swift
@@ -202,25 +202,15 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
         tableView.autosaveName = "FinderTwo.FileList"
         tableView.autosaveTableColumns = true
 
-        // Columns
-        addColumn(id: "name", title: "Name", width: 340, minWidth: 120, sortKey: SortKey.name.rawValue)
-        addColumn(id: "modified", title: "Date Modified", width: 170, minWidth: 110, sortKey: SortKey.dateModified.rawValue)
-        addColumn(id: "size", title: "Size", width: 90, minWidth: 60, sortKey: SortKey.size.rawValue, alignment: .right)
-        addColumn(id: "kind", title: "Kind", width: 130, minWidth: 70, sortKey: SortKey.kind.rawValue)
+        // Columns — every available column is created up front (so width/order
+        // autosave is stable) and hidden/shown from the persisted visible set.
+        for col in ListColumn.allCases { addColumn(col) }
+        applyColumnVisibility()
         suppressSortSave = true
         tableView.sortDescriptors = [NSSortDescriptor(key: SortKey.name.rawValue, ascending: true)]
         suppressSortSave = false
 
-        // Column chooser: right-click the header to show/hide columns (Name stays).
-        let headerMenu = NSMenu()
-        for col in tableView.tableColumns where col.identifier.rawValue != "name" {
-            let it = NSMenuItem(title: col.title, action: #selector(toggleColumn(_:)), keyEquivalent: "")
-            it.representedObject = col.identifier.rawValue
-            it.target = self
-            it.state = col.isHidden ? .off : .on
-            headerMenu.addItem(it)
-        }
-        tableView.headerView?.menu = headerMenu
+        rebuildHeaderMenu()
 
         scrollView.documentView = tableView
         scrollView.focusRingType = .none   // no blue focus outline around the list
@@ -267,14 +257,52 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
         tableView.reloadData()
     }
 
-    private func addColumn(id: String, title: String, width: CGFloat, minWidth: CGFloat, sortKey: String, alignment: NSTextAlignment = .left) {
-        let c = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(id))
-        c.title = title
-        c.width = width
-        c.minWidth = minWidth
-        c.sortDescriptorPrototype = NSSortDescriptor(key: sortKey, ascending: true)
-        c.headerCell.alignment = alignment == .right ? .right : .left
+    private func addColumn(_ col: ListColumn) {
+        let c = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(col.id))
+        c.title = col.title
+        c.width = col.defaultWidth
+        c.minWidth = col.minWidth
+        // Only columns with a FileItem-backed ordering get a clickable sort
+        // header; Tags / Comments have no sort key.
+        if let key = col.sortKey {
+            c.sortDescriptorPrototype = NSSortDescriptor(key: key.rawValue, ascending: true)
+        }
+        c.headerCell.alignment = col.alignment == .right ? .right : .left
         tableView.addTableColumn(c)
+    }
+
+    /// Show/hide each table column to match the persisted visible set. Order is
+    /// left to NSTableView's column autosave (and user drag), so we only flip
+    /// `isHidden` here.
+    private func applyColumnVisibility() {
+        for c in tableView.tableColumns {
+            guard let col = ListColumn(rawValue: c.identifier.rawValue) else { continue }
+            c.isHidden = !ListColumnPrefs.isVisible(col)
+        }
+    }
+
+    /// Build the header right-click menu: one checkmark item per toggleable
+    /// column (the mandatory Name column is omitted — it can't be hidden).
+    private func rebuildHeaderMenu() {
+        let menu = NSMenu()
+        for col in ListColumn.allCases where !col.isMandatory {
+            let it = NSMenuItem(title: col.title, action: #selector(toggleColumn(_:)), keyEquivalent: "")
+            it.representedObject = col.id
+            it.target = self
+            it.state = ListColumnPrefs.isVisible(col) ? .on : .off
+            menu.addItem(it)
+        }
+        menu.addItem(NSMenuItem.separator())
+        let reset = NSMenuItem(title: "Reset to Default Columns", action: #selector(resetColumns), keyEquivalent: "")
+        reset.target = self
+        menu.addItem(reset)
+        tableView.headerView?.menu = menu
+    }
+
+    @objc private func resetColumns() {
+        ListColumnPrefs.reset()
+        applyColumnVisibility()
+        rebuildHeaderMenu()   // refresh the checkmarks
     }
 
     /// A just-created item (New Folder / New File) to select — and optionally
@@ -463,6 +491,45 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
         return "…"   // computing
     }
 
+    // MARK: Spotlight metadata cache (Comments / Date Added columns)
+    // MDItemCreateWithURL does synchronous disk I/O that can stall on a big or
+    // networked folder, so — exactly like the folder-size cache above — fetch it
+    // off-main and repaint the one row when it lands. One fetch fills both the
+    // Comments and Date Added columns for that URL.
+    private final class SpotlightEntry {
+        let comment: String
+        let dateAdded: Date?
+        init(comment: String, dateAdded: Date?) { self.comment = comment; self.dateAdded = dateAdded }
+    }
+    private static let spotlightQueue = DispatchQueue(label: "FinderTwo.spotlight", qos: .utility)
+    private let spotlightCache: NSCache<NSURL, SpotlightEntry> = {
+        let c = NSCache<NSURL, SpotlightEntry>(); c.countLimit = 4096; return c
+    }()
+    private var spotlightInFlight: Set<URL> = []
+
+    /// Cached Spotlight metadata for `url`, kicking off an off-main fetch (and
+    /// returning nil) the first time. The row is reloaded when the fetch lands.
+    private func spotlightEntry(for url: URL) -> SpotlightEntry? {
+        if let e = spotlightCache.object(forKey: url as NSURL) { return e }
+        if !spotlightInFlight.contains(url) {
+            spotlightInFlight.insert(url)
+            FileListController.spotlightQueue.async { [weak self] in
+                let entry = SpotlightEntry(comment: SpotlightMetadata.finderComment(url),
+                                           dateAdded: SpotlightMetadata.dateAdded(url))
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.spotlightCache.setObject(entry, forKey: url as NSURL)
+                    self.spotlightInFlight.remove(url)
+                    if let idx = self.urlToRowIndex[url], idx < self.tableView.numberOfRows {
+                        self.tableView.reloadData(forRowIndexes: IndexSet(integer: idx),
+                                                  columnIndexes: IndexSet(integersIn: 0..<self.tableView.numberOfColumns))
+                    }
+                }
+            }
+        }
+        return nil   // fetching
+    }
+
     static func recursiveSize(_ url: URL) -> Int64 {
         var total: Int64 = 0
         let keys: [URLResourceKey] = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
@@ -478,9 +545,11 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
 
     @objc private func toggleColumn(_ sender: NSMenuItem) {
         guard let id = sender.representedObject as? String,
-              let col = tableView.tableColumns.first(where: { $0.identifier.rawValue == id }) else { return }
-        col.isHidden.toggle()
-        sender.state = col.isHidden ? .off : .on
+              let col = ListColumn(rawValue: id),
+              let tableCol = tableView.tableColumns.first(where: { $0.identifier.rawValue == id }) else { return }
+        let nowVisible = ListColumnPrefs.toggle(col)   // persists the new set
+        tableCol.isHidden = !nowVisible
+        sender.state = nowVisible ? .on : .off
     }
 
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
@@ -508,12 +577,12 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
             return cell
         }
         guard let col = tableColumn, let mi = modelIndex(forRow: row),
-              model.items.indices.contains(mi) else { return nil }
+              model.items.indices.contains(mi),
+              let column = ListColumn(rawValue: col.identifier.rawValue) else { return nil }
         let item = model.items[mi]
-        let id = col.identifier.rawValue
 
-        switch id {
-        case "name":
+        switch column {
+        case .name:
             let cellId = NSUserInterfaceItemIdentifier("NameCell")
             let cell = (tableView.makeView(withIdentifier: cellId, owner: nil) as? NameCell) ?? NameCell()
             cell.identifier = cellId
@@ -521,9 +590,11 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
             cell.configure(with: item, gitState: model.gitStates[item.name])
             cell.imageView?.image = thumbnail(for: item, indexPath: row)
             return cell
-        case "modified":
+        case .modified:
             return makeTextCell(text: DateFormatterCache.string(item.modified), color: secondaryTextColor)
-        case "size":
+        case .created:
+            return makeTextCell(text: DateFormatterCache.string(item.created), color: secondaryTextColor)
+        case .size:
             let sizeText: String
             if item.isDirectory {
                 sizeText = Settings.calculateFolderSizes ? folderSizeText(for: item.url) : "—"
@@ -531,11 +602,32 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
                 sizeText = SizeFormatter.string(item.size)
             }
             return makeTextCell(text: sizeText, color: secondaryTextColor, alignment: .right)
-        case "kind":
+        case .kind:
             return makeTextCell(text: item.kindDescription, color: secondaryTextColor)
-        default:
-            return nil
+        case .tags:
+            // Reuse the memoized color read from the name cell's dots (no extra
+            // getxattr per row); show colored dots + comma-joined tag names.
+            let colors = Tags.cachedColors(for: item.url, modified: item.modified)
+            return makeTagsCell(colors: colors, names: tagNames(for: item))
+        case .comments:
+            let comment = spotlightEntry(for: item.url)?.comment ?? ""
+            return makeTextCell(text: comment, color: secondaryTextColor)
+        case .dateAdded:
+            let text: String
+            if let entry = spotlightEntry(for: item.url) {
+                text = entry.dateAdded.map { DateFormatterCache.string($0) } ?? "—"
+            } else {
+                text = "…"   // Spotlight fetch in flight
+            }
+            return makeTextCell(text: text, color: secondaryTextColor)
         }
+    }
+
+    /// Tag names for a file (full set, including uncolored tags) for the Tags
+    /// column. Goes through Tags.read, which is memoized for color dots; the name
+    /// read is cheap relative to a Spotlight fetch and only runs for visible rows.
+    private func tagNames(for item: FileItem) -> [String] {
+        Tags.read(item.url).map { $0.name }
     }
 
     func tableView(_ tableView: NSTableView, isGroupRow row: Int) -> Bool {
@@ -709,6 +801,31 @@ final class FileListController: NSViewController, NSTableViewDataSource, NSTable
         // Honor the live font size (theme base + density delta) — secondary
         // columns sit one point smaller than the name column.
         cell.textField?.font = NSFont.systemFont(ofSize: max(9, ThemeManager.shared.effectiveFontSize - 1))
+        return cell
+    }
+
+    /// Tags column cell: leading colored dots (one per tag color) followed by the
+    /// comma-joined tag names. Renders into the same TextCell as other secondary
+    /// columns so it picks up theme color/font; the dots ride in an attributed
+    /// prefix the way the name cell shows them.
+    private func makeTagsCell(colors: [Tags.Color], names: [String]) -> NSView {
+        let cell = makeTextCell(text: "", color: secondaryTextColor)
+        guard let tf = (cell as? NSTableCellView)?.textField else { return cell }
+        if colors.isEmpty && names.isEmpty {
+            tf.attributedStringValue = NSAttributedString(string: "")
+            return cell
+        }
+        let s = NSMutableAttributedString()
+        let dotFont = NSFont.systemFont(ofSize: 9)
+        for c in colors.prefix(5) {
+            s.append(NSAttributedString(string: "● ", attributes: [.foregroundColor: c.nsColor, .font: dotFont]))
+        }
+        if !names.isEmpty {
+            s.append(NSAttributedString(string: names.joined(separator: ", "),
+                                        attributes: [.foregroundColor: secondaryTextColor,
+                                                     .font: tf.font ?? NSFont.systemFont(ofSize: 12)]))
+        }
+        tf.attributedStringValue = s
         return cell
     }
 


### PR DESCRIPTION
## What

The list view (`FileListController`) had a fixed column set (Name / Date Modified / Size / Kind). This makes the columns user-configurable from the **column-header right-click menu** (toggle on/off) and adds:

- **Tags** — Finder color tags (`kMDItemUserTags`), rendered as colored dots + tag names.
- **Comments** — Spotlight `kMDItemFinderComment`.
- **Date Added** — Spotlight `kMDItemDateAdded`.
- **Date Created** — `kMDItemContentCreationDate` (already on `FileItem`).

Plus a **Reset to Default Columns** item at the bottom of the header menu.

## How

- **`Model/ListColumns.swift`** — new. `ListColumn` is the available column set *as data* (id, title, default width/min-width, sort key, alignment, mandatory flag, "needs Spotlight" flag). `ListColumnPrefs` persists the chosen visible set under the `FinderTwo.*` UserDefaults namespace, with a separate `.test` key under `FT_HEADLESS_TESTING=1` (mirrors `FolderViewPrefs`). The setter canonicalizes (dedupes, forces the mandatory Name column on, keeps enum order); the getter falls back to the default set when nothing is saved or the stored value is corrupt.
- **`FS/SpotlightMetadata.swift`** — new. Thin wrapper that reads `kMDItemFinderComment` / `kMDItemDateAdded` via `MDItemCreateWithURL` (the same Spotlight API already used in `BatchRenameSheetController`).
- **`UI/FileListController.swift`** — column creation, the header chooser menu, and cell rendering all now read from `ListColumn`, so adding a column is a single enum case. The Tags cell reuses the already-memoized tag-color read (no extra `getxattr` per row). Comments / Date Added are fetched **off the main thread** through an `NSCache` + in-flight `Set` (the exact pattern the existing folder-size column uses), with the row repainted when the value lands — so a large or networked folder never stalls the main thread on `MDItemCreateWithURL`. Cells show `…` while a fetch is in flight.
- **Persistence scope (deliberate):** column **width and order** continue to use NSTableView's existing `autosaveTableColumns`; column **visibility** is owned by `ListColumnPrefs` and re-applied on load (global, like Finder's View Options → "use as default"). Per-folder view memory (`FolderViewPrefs`) stays scoped to view mode + sort, which is unchanged. See "Deferred" for the per-folder-columns option.

## Headless testing

- `./build.sh debug` — **compiles clean, zero warnings.**
- `Sources/FinderTwo/Tests/TestRunner.swift` — added two off-screen assertion blocks:
  - **Column model / persistence:** defaults match the historical layout; Tags/Comments/Date-Added are non-sortable; Spotlight flags are correct; toggle + persistence round-trips; an empty set collapses to just Name; corrupt stored data falls back to defaults; `reset()` restores defaults.
  - **Live integration:** the real `FileListController` builds every `ListColumn`, its header chooser menu lists exactly the toggleable columns (and omits mandatory Name), and a hidden-by-default column (Tags) is actually hidden on a fresh table.
- `./smoketest.sh` — reached **577 passed / 0 failed** with these changes (baseline is 549; the delta is the new column assertions). **All 17 new column assertions pass.**
- `./guitest.sh` — **0 failures** (menu/shortcut audit unaffected — the header context menu isn't part of the main menu bar).

> ⚠️ **Re-run the suites before merging.** Late in the dev session the CI/dev host began SIGTERM-ing the launched GUI binary within seconds (eventually instantly at launch), which prevented the full `smoketest.sh` / `guitest.sh` from reaching their final summary line on the last attempts. This is environmental, not a code regression: (a) the **clean baseline with these changes stashed dies identically**, (b) every assertion that *did* execute (up to 517/577) reported **zero failures**, including all new column tests, and (c) the complete `577/0` smoke run and `0`-failure guitest above were produced earlier in the same session with this exact code. The build (which doesn't launch the app) stays deterministically clean. Please run `./smoketest.sh` and `./guitest.sh` once in a clean environment to confirm green.

## What to check headed

- Right-click the list-view **column header** → toggle Tags / Comments / Date Added / Date Created on and off; confirm checkmarks and the live column show/hide.
- **Tags** column shows the right color dots + names; toggling a tag via the row context menu updates the column live.
- **Comments** / **Date Added** populate (briefly show `…` then fill) and don't hitch the UI on a large folder (e.g. a big `~/Downloads`).
- Quit and relaunch → the chosen columns persist; **Reset to Default Columns** returns to Name/Modified/Size/Kind.
- Column width/order drag still persists (NSTableView autosave) across relaunch.
- Sort headers still work for Name/Modified/Created/Size/Kind; Tags/Comments/Date-Added headers are intentionally non-sortable.

## Deferred

- **Per-folder column sets.** Columns are global today (matches Finder's default and avoids fighting NSTableView's global width/order autosave). Per-folder overrides could be layered onto `FolderViewPrefs` later if wanted.
- **Sorting by Date Added / Comments / Tags.** These have no `FileItem`-backed ordering yet, so their headers don't sort. Adding `dateAdded` to the Spotlight fetch-and-cache path and into `SortDescriptor` would enable it.
