### PR TITLE
Explorer-style expandable folder tree in the sidebar

### DIFF
--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -2267,7 +2267,111 @@ final class TestRunner {
             assert("command palette Open With test file exists", false, "test file not found")
         }
 
+        // --- T62: Explorer-style sidebar folder tree (lazy, off-screen) ---
+        runSidebarFolderTreeTests(sandbox)
+
         finish()
+    }
+
+    /// Off-screen assertions for the lazily-expanding sidebar folder tree.
+    /// Verifies: a node's children equal the subdirectories of a known temp
+    /// dir; expansion is lazy (children load only on first access); and empty,
+    /// unreadable, file, and symlink-cycle folders all degrade without crashing.
+    private func runSidebarFolderTreeTests(_ sandbox: URL) {
+        let fm = FileManager.default
+        let treeRoot = sandbox.appendingPathComponent("tree_root_\(UUID().uuidString)")
+        try? fm.createDirectory(at: treeRoot, withIntermediateDirectories: true)
+        // Three subdirectories + two files + one hidden dir.
+        for d in ["zebra", "alpha", "Mango"] {
+            try? fm.createDirectory(at: treeRoot.appendingPathComponent(d), withIntermediateDirectories: true)
+        }
+        try? "x".write(to: treeRoot.appendingPathComponent("file1.txt"), atomically: true, encoding: .utf8)
+        try? "x".write(to: treeRoot.appendingPathComponent("file2.txt"), atomically: true, encoding: .utf8)
+        try? fm.createDirectory(at: treeRoot.appendingPathComponent(".hidden_dir"), withIntermediateDirectories: true)
+
+        // Laziness: a freshly built node has NOT scanned the disk yet.
+        let node = SidebarController.testMakeTreeNode(url: treeRoot)
+        assert("tree node is not loaded before expansion",
+               !SidebarController.testIsLoaded(node), "node pre-loaded")
+
+        // Children equal the directory's subdirectories (folders only, no files),
+        // sorted case-insensitively. Hidden dirs are excluded by default.
+        let childURLs = SidebarController.testLoadChildURLs(of: node)
+        let childNames = childURLs.map { $0.lastPathComponent }
+        assert("tree node loaded after first child access",
+               SidebarController.testIsLoaded(node), "still not loaded")
+        assert("tree children are exactly the visible subdirectories (sorted, no files)",
+               childNames == ["alpha", "Mango", "zebra"], "got=\(childNames)")
+        let onDiskSubdirs = Set(((try? fm.contentsOfDirectory(atPath: treeRoot.path)) ?? [])
+            .filter { name in
+                var isDir: ObjCBool = false
+                fm.fileExists(atPath: treeRoot.appendingPathComponent(name).path, isDirectory: &isDir)
+                return isDir.boolValue && !name.hasPrefix(".")
+            })
+        assert("tree children match the directory's actual subdirectory set",
+               Set(childNames) == onDiskSubdirs, "tree=\(Set(childNames)) disk=\(onDiskSubdirs)")
+
+        // Lazy expansion populates a child's OWN children on demand.
+        let nested = treeRoot.appendingPathComponent("alpha")
+        try? fm.createDirectory(at: nested.appendingPathComponent("deep"), withIntermediateDirectories: true)
+        if let alphaNode = SidebarController.testLoadChildren(of: node).first(where: { $0.url.lastPathComponent == "alpha" }) {
+            assert("nested tree node starts unloaded (lazy)",
+                   !SidebarController.testIsLoaded(alphaNode), "nested pre-loaded")
+            let grand = SidebarController.testLoadChildURLs(of: alphaNode).map { $0.lastPathComponent }
+            assert("expanding a nested node lists ITS subdirectories",
+                   grand == ["deep"], "got=\(grand)")
+        } else {
+            assert("found nested 'alpha' tree node", false, "missing")
+        }
+
+        // Empty folder → zero children, no crash.
+        let emptyDir = treeRoot.appendingPathComponent("Mango")
+        let emptyNode = SidebarController.testMakeTreeNode(url: emptyDir)
+        assert("empty folder yields no children (no crash)",
+               SidebarController.testLoadChildURLs(of: emptyNode).isEmpty, "non-empty")
+
+        // A file (non-directory) node → zero children, no crash.
+        let fileNode = SidebarController.testMakeTreeNode(url: treeRoot.appendingPathComponent("file1.txt"))
+        assert("file node yields no children (no crash)",
+               SidebarController.testLoadChildURLs(of: fileNode).isEmpty, "file had children")
+
+        // Unreadable (permission-denied) folder → zero children, no crash.
+        let denied = treeRoot.appendingPathComponent("denied")
+        try? fm.createDirectory(at: denied, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: denied.appendingPathComponent("inside"), withIntermediateDirectories: true)
+        try? fm.setAttributes([.posixPermissions: 0], ofItemAtPath: denied.path)
+        let deniedNode = SidebarController.testMakeTreeNode(url: denied)
+        let deniedChildren = SidebarController.testLoadChildURLs(of: deniedNode)
+        assert("permission-denied folder degrades to no children (no crash)",
+               deniedChildren.isEmpty, "got=\(deniedChildren.map { $0.lastPathComponent })")
+        // Restore perms so the sandbox can be torn down.
+        try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: denied.path)
+
+        // Symlink cycle: a symlink pointing back to its own parent must NOT be
+        // followed when enumerating, so expansion can't recurse forever.
+        let loopDir = treeRoot.appendingPathComponent("loopdir")
+        try? fm.createDirectory(at: loopDir, withIntermediateDirectories: true)
+        try? fm.createSymbolicLink(at: loopDir.appendingPathComponent("self_link"),
+                                   withDestinationURL: loopDir)
+        let loopNode = SidebarController.testMakeTreeNode(url: treeRoot)
+        // Find the freshly-added loopdir node and expand it.
+        let freshChildren = SidebarController.testLoadChildren(of: SidebarController.testMakeTreeNode(url: treeRoot))
+        if let loopChild = freshChildren.first(where: { $0.url.lastPathComponent == "loopdir" }) {
+            let loopKids = SidebarController.testLoadChildURLs(of: loopChild).map { $0.lastPathComponent }
+            assert("symlink-to-parent is dropped (cycle guard)",
+                   !loopKids.contains("self_link"), "followed loop: \(loopKids)")
+        } else {
+            assert("found loopdir tree node", false, "missing")
+        }
+        _ = node; _ = loopNode  // silence unused in case branches above don't fire
+
+        // The live sidebar exposes a "Folders" section with browsable roots.
+        let liveSidebar = SidebarController(); _ = liveSidebar.view
+        assert("live sidebar has a Folders section",
+               liveSidebar.testHasFoldersSection, "no Folders section")
+        assert("folder tree roots include the home folder",
+               liveSidebar.testTreeRootTitles.contains(NSUserName()),
+               "roots=\(liveSidebar.testTreeRootTitles)")
     }
 
     /// Build every modal/window controller and force its view to load. A crash

--- a/Sources/FinderTwo/UI/SidebarController.swift
+++ b/Sources/FinderTwo/UI/SidebarController.swift
@@ -12,7 +12,14 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
     private final class Section {
         let title: String
         var items: [Entry]
-        init(title: String, items: [Entry]) { self.title = title; self.items = items }
+        /// Non-nil for the folder-tree section, whose top-level rows are
+        /// lazily-expandable `TreeNode`s rather than flat `Entry`s.
+        var treeRoots: [TreeNode]?
+        init(title: String, items: [Entry], treeRoots: [TreeNode]? = nil) {
+            self.title = title; self.items = items; self.treeRoots = treeRoots
+        }
+        /// How many top-level rows this section shows.
+        var childCount: Int { treeRoots?.count ?? items.count }
     }
     private final class Entry {
         let title: String
@@ -23,12 +30,112 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
         }
     }
 
+    /// A node in the Explorer-style folder tree. Children are loaded *lazily*
+    /// (only when the node is expanded) via `FastDirScan`, so deep hierarchies
+    /// are never pre-scanned — see `loadChildrenIfNeeded`. Reference type because
+    /// `NSOutlineView` keys items by object identity.
+    final class TreeNode {
+        let url: URL
+        let title: String
+        let icon: NSImage
+        let isDirectory: Bool
+        /// Canonical (symlink-resolved) paths of this node and every ancestor,
+        /// used to break symlink cycles when enumerating children.
+        let ancestorRealPaths: Set<String>
+        /// nil until the node is first expanded; non-nil (possibly empty) after.
+        private(set) var children: [TreeNode]?
+        var isLoaded: Bool { children != nil }
+
+        init(url: URL, title: String, icon: NSImage, isDirectory: Bool,
+             ancestorRealPaths: Set<String> = []) {
+            self.url = url
+            self.title = title
+            self.icon = icon
+            self.isDirectory = isDirectory
+            self.ancestorRealPaths = ancestorRealPaths
+        }
+
+        /// Lazily enumerate this node's immediate subdirectories with the fast
+        /// scanner, sorted case-insensitively. Hidden folders are skipped unless
+        /// the user has "Show Hidden Files" on. Symlinked directories whose real
+        /// path is already an ancestor are dropped to prevent infinite recursion.
+        /// Idempotent: only the first call hits the disk.
+        @discardableResult
+        func loadChildrenIfNeeded() -> [TreeNode] {
+            if let children { return children }
+            guard isDirectory else { children = []; return [] }
+            // The tree follows the user's global "show hidden" default; per-pane
+            // toggles don't apply to the always-present sidebar.
+            let showHidden = Settings.showHiddenByDefault
+            let myReal = (url.resolvingSymlinksInPath().path as NSString).standardizingPath
+            let inheritedReal = ancestorRealPaths.union([myReal])
+
+            var dirs = FastDirScan.list(url).filter { $0.isDirectory }
+            if !showHidden { dirs = dirs.filter { !$0.isHidden } }
+            dirs.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+            var built: [TreeNode] = []
+            built.reserveCapacity(dirs.count)
+            for e in dirs {
+                let childReal = (e.url.resolvingSymlinksInPath().path as NSString).standardizingPath
+                // Cycle guard: a symlink pointing back up the tree (or to itself)
+                // would otherwise let the user expand forever.
+                if e.isSymlink && inheritedReal.contains(childReal) { continue }
+                built.append(TreeNode(
+                    url: e.url, title: e.name,
+                    icon: SidebarController.folderIcon(for: e.url),
+                    isDirectory: true, ancestorRealPaths: inheritedReal))
+            }
+            children = built
+            return built
+        }
+
+        /// Drop cached children so the next expansion re-scans (used when the
+        /// "Show Hidden Files" setting flips, which changes what's visible).
+        func invalidateChildren() { children = nil }
+    }
+
     private var sections: [Section] = []
+    /// Top-level roots of the folder tree (Home + mounted volumes). Kept around
+    /// so their lazily-built children survive `reloadData` across bookmark/theme
+    /// changes (rebuilding them would collapse the user's expanded folders).
+    private var treeRoots: [TreeNode] = []
     private var selectedURL: URL?
 
     var testEntryTitles: [String] {
         sections.flatMap { $0.items.map { $0.title } }
     }
+
+    // MARK: Folder-tree test hooks (off-screen)
+
+    /// Titles of the folder-tree's top-level roots (Home + volumes).
+    var testTreeRootTitles: [String] { treeRoots.map { $0.title } }
+
+    /// Whether the live sidebar exposes a "Folders" section.
+    var testHasFoldersSection: Bool {
+        sections.contains { $0.title == SidebarController.foldersSectionTitle }
+    }
+
+    /// Build a detached tree node rooted at `url` (used by tests to point the
+    /// lazy-loader at a known temp directory without touching the live sidebar).
+    static func testMakeTreeNode(url: URL) -> TreeNode {
+        let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? true
+        return TreeNode(url: url, title: url.lastPathComponent,
+                        icon: folderIcon(for: url), isDirectory: isDir)
+    }
+
+    /// Lazily load and return the immediate child folder nodes of `node`.
+    static func testLoadChildren(of node: TreeNode) -> [TreeNode] {
+        node.loadChildrenIfNeeded()
+    }
+
+    /// Lazily load and return the immediate child folder URLs of `node`.
+    static func testLoadChildURLs(of node: TreeNode) -> [URL] {
+        node.loadChildrenIfNeeded().map { $0.url }
+    }
+
+    /// Whether a node has already loaded its children (proves laziness).
+    static func testIsLoaded(_ node: TreeNode) -> Bool { node.isLoaded }
 
     /// Themed tint that covers the vibrancy for non-System themes so the
     /// sidebar background matches the rest of the window.
@@ -117,12 +224,37 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
                                                name: SidebarBookmarks.didChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(bookmarksChanged),
                                                name: SmartFolders.didChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(settingsChanged),
+                                               name: Settings.didChange, object: nil)
+        lastShowHiddenDefault = Settings.showHiddenByDefault
     }
 
     @objc private func bookmarksChanged() {
         buildSections()
         outline.reloadData()
         for s in sections { outline.expandItem(s) }
+    }
+
+    /// Tracks the global show-hidden default so we only rescan the tree when it
+    /// actually flips (Settings.didChange also fires for theme/density/etc.).
+    private var lastShowHiddenDefault = false
+
+    @objc private func settingsChanged() {
+        let now = Settings.showHiddenByDefault
+        guard now != lastShowHiddenDefault else { return }
+        lastShowHiddenDefault = now
+        // The set of visible subfolders changed: drop every cached subtree so the
+        // next expansion rescans with the new hidden-files rule.
+        invalidateAllTreeChildren(treeRoots)
+        outline.reloadData()
+        for s in sections { outline.expandItem(s) }
+    }
+
+    private func invalidateAllTreeChildren(_ nodes: [TreeNode]) {
+        for n in nodes {
+            if let kids = n.children { invalidateAllTreeChildren(kids) }
+            n.invalidateChildren()
+        }
     }
 
     deinit { NotificationCenter.default.removeObserver(self) }
@@ -132,8 +264,24 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
         let row = outline.clickedRow
-        guard row >= 0, let entry = outline.item(atRow: row) as? Entry,
-              !SidebarController.isTagURL(entry.url) else { return }
+        guard row >= 0 else { return }
+        let item = outline.item(atRow: row)
+        // Folder-tree nodes get open-in-tab/window plus an Add to Sidebar shortcut.
+        if let node = item as? TreeNode {
+            let openTab = NSMenuItem(title: "Open in New Tab", action: #selector(ctxOpenNewTab(_:)), keyEquivalent: "")
+            let openWin = NSMenuItem(title: "Open in New Window", action: #selector(ctxOpenNewWindow(_:)), keyEquivalent: "")
+            for it in [openTab, openWin] { it.target = self; it.representedObject = node.url; menu.addItem(it) }
+            menu.addItem(.separator())
+            if SidebarBookmarks.contains(node.url) {
+                let rm = NSMenuItem(title: "Remove from Sidebar", action: #selector(ctxRemoveBookmark(_:)), keyEquivalent: "")
+                rm.target = self; rm.representedObject = node.url; menu.addItem(rm)
+            } else {
+                let add = NSMenuItem(title: "Add to Sidebar", action: #selector(ctxAddBookmark(_:)), keyEquivalent: "")
+                add.target = self; add.representedObject = node.url; menu.addItem(add)
+            }
+            return
+        }
+        guard let entry = item as? Entry, !SidebarController.isTagURL(entry.url) else { return }
         let openTab = NSMenuItem(title: "Open in New Tab", action: #selector(ctxOpenNewTab(_:)), keyEquivalent: "")
         let openWin = NSMenuItem(title: "Open in New Window", action: #selector(ctxOpenNewWindow(_:)), keyEquivalent: "")
         for it in [openTab, openWin] { it.target = self; it.representedObject = entry.url; menu.addItem(it) }
@@ -158,6 +306,7 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
     @objc private func ctxOpenNewTab(_ s: NSMenuItem) { if let u = s.representedObject as? URL { onOpenInNewTab?(u) } }
     @objc private func ctxOpenNewWindow(_ s: NSMenuItem) { if let u = s.representedObject as? URL { onOpenInNewWindow?(u) } }
     @objc private func ctxRemoveBookmark(_ s: NSMenuItem) { if let u = s.representedObject as? URL { SidebarBookmarks.remove(u) } }
+    @objc private func ctxAddBookmark(_ s: NSMenuItem) { if let u = s.representedObject as? URL { SidebarBookmarks.add(u) } }
     @objc private func ctxDeleteSmartFolder(_ s: NSMenuItem) {
         if let u = s.representedObject as? URL, let id = SidebarController.smartFolderId(from: u) {
             SmartFolders.remove(id: id)
@@ -193,6 +342,7 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
 
     func highlight(url: URL) {
         selectedURL = url
+        // Prefer a flat shortcut row (Favorites/Locations) for the active path.
         for s in sections {
             if let e = s.items.first(where: { $0.url == url }) {
                 let row = outline.row(forItem: e)
@@ -202,13 +352,94 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
                 }
             }
         }
+        // Otherwise, if a matching folder-tree node is already on screen (we only
+        // search ALREADY-LOADED nodes — never force a scan just to highlight),
+        // select it so clicking a tree folder keeps its row highlighted.
+        if let node = visibleTreeNode(matching: url) {
+            let row = outline.row(forItem: node)
+            if row >= 0 {
+                outline.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+                return
+            }
+        }
         outline.deselectAll(nil)
     }
 
+    /// Find an already-loaded tree node whose URL matches `url`, without
+    /// triggering any lazy scan (we read cached children only).
+    private func visibleTreeNode(matching url: URL) -> TreeNode? {
+        func search(_ nodes: [TreeNode]) -> TreeNode? {
+            for n in nodes {
+                if n.url == url { return n }
+                if let kids = n.children, let hit = search(kids) {
+                    return hit
+                }
+            }
+            return nil
+        }
+        return search(treeRoots)
+    }
+
+    /// The navigable URL for a clicked/selected sidebar row, if any.
+    private func navigableURL(forRow row: Int) -> URL? {
+        guard row >= 0 else { return nil }
+        let item = outline.item(atRow: row)
+        if let entry = item as? Entry { return entry.url }
+        if let node = item as? TreeNode { return node.url }
+        return nil
+    }
+
     @objc private func handleClick() {
-        let row = outline.selectedRow
-        guard row >= 0, let entry = outline.item(atRow: row) as? Entry else { return }
-        onSelect?(entry.url)
+        if let url = navigableURL(forRow: outline.selectedRow) { onSelect?(url) }
+    }
+
+    /// Section title for the Explorer-style folder tree.
+    static let foldersSectionTitle = "Folders"
+
+    /// Icon for a folder/volume URL, falling back to the generic folder icon for
+    /// TCC-protected paths we can't read without Full Disk Access (so we don't
+    /// trip a permission prompt just to draw a sidebar row). Sized for the tree.
+    static func folderIcon(for url: URL) -> NSImage {
+        let icon: NSImage
+        if !PermissionsManager.hasFullDiskAccess && PermissionsManager.isProtectedPath(url.path) {
+            icon = NSWorkspace.shared.icon(for: .folder)
+        } else {
+            icon = NSWorkspace.shared.icon(forFile: url.path)
+        }
+        icon.size = NSSize(width: 16, height: 16)
+        return icon
+    }
+
+    /// (Re)build the folder-tree roots: Home, then each browsable mounted
+    /// volume. Only the *roots* are created here; their subfolders load lazily on
+    /// expansion. Existing roots are reused so already-expanded subtrees aren't
+    /// thrown away on a rebuild (e.g. when bookmarks or the theme change).
+    private func buildTreeRoots() {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser
+        var existing: [String: TreeNode] = [:]
+        for r in treeRoots { existing[r.url.path] = r }
+
+        func root(url: URL, title: String) -> TreeNode {
+            if let r = existing[url.path] { return r }
+            return TreeNode(url: url, title: title,
+                            icon: SidebarController.folderIcon(for: url),
+                            isDirectory: true)
+        }
+
+        var roots: [TreeNode] = [root(url: home, title: NSUserName())]
+        let volKeys: [URLResourceKey] = [.volumeNameKey, .volumeIsBrowsableKey]
+        if let volumes = fm.mountedVolumeURLs(includingResourceValuesForKeys: volKeys,
+                                              options: [.skipHiddenVolumes]) {
+            for v in volumes {
+                guard let rv = try? v.resourceValues(forKeys: Set(volKeys)),
+                      rv.volumeIsBrowsable == true else { continue }
+                let name = v.path == "/" ? (rv.volumeName ?? "Macintosh HD")
+                                         : (rv.volumeName ?? v.lastPathComponent)
+                roots.append(root(url: v, title: name))
+            }
+        }
+        treeRoots = roots
     }
 
     private func buildSections() {
@@ -291,11 +522,19 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
             Entry(title: f.name, url: SidebarController.smartFolderURL(id: f.id), icon: gear)
         }
 
+        // Explorer-style folder tree: Home + mounted volumes, each expandable
+        // into its subfolders on demand. Built last so it sits beneath the flat
+        // shortcut sections.
+        buildTreeRoots()
+        let foldersSection = Section(title: SidebarController.foldersSectionTitle,
+                                     items: [], treeRoots: treeRoots)
+
         sections = [
             Section(title: "Favorites", items: favs),
             Section(title: "Locations", items: locations),
             Section(title: "Smart Folders", items: smartItems),
         ].filter { !$0.items.isEmpty }
+        sections.append(foldersSection)
 
         // Populate Tags section asynchronously — Spotlight call.
         TagIndex.allTagSummaries { [weak self] summaries in
@@ -309,7 +548,14 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
                 return Entry(title: label, url: URL(fileURLWithPath: "/tag/\(s.tag.name)"),
                              icon: tinted)
             }
-            self.sections.append(Section(title: "Tags", items: tagItems))
+            // Keep the folder tree last: drop Tags in just above it if present.
+            let tagSection = Section(title: "Tags", items: tagItems)
+            if let folderIdx = self.sections.firstIndex(where: {
+                $0.title == SidebarController.foldersSectionTitle }) {
+                self.sections.insert(tagSection, at: folderIdx)
+            } else {
+                self.sections.append(tagSection)
+            }
             self.outline.reloadData()
             for s in self.sections { self.outline.expandItem(s) }
         }
@@ -338,6 +584,9 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
     func outlineView(_ outlineView: NSOutlineView, persistentObjectForItem item: Any?) -> Any? {
         if let s = item as? Section { return "section:\(s.title)" }
         if let e = item as? Entry { return "entry:\(e.url.path)" }
+        // Folder-tree expansion is intentionally NOT persisted: restoring it
+        // would force a scan of every saved path on launch, against the lazy
+        // design. Sections (incl. "Folders") still persist their expanded state.
         return nil
     }
     func outlineView(_ outlineView: NSOutlineView, itemForPersistentObject object: Any) -> Any? {
@@ -359,20 +608,39 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
 
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
         if item == nil { return sections.count }
-        if let s = item as? Section { return s.items.count }
+        if let s = item as? Section { return s.childCount }
+        // A tree folder: lazily scan its subdirectories the first time its count
+        // is requested (i.e. when it's being expanded), then serve the cache.
+        // NSOutlineView only asks this for items it's about to display, so
+        // collapsed/deep folders are never scanned — that's the lazy guarantee.
+        if let node = item as? TreeNode { return node.loadChildrenIfNeeded().count }
         return 0
     }
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
         if item == nil {
             return sections.indices.contains(index) ? sections[index] : Section(title: "", items: [])
         }
-        guard let section = item as? Section, section.items.indices.contains(index) else {
-            return Section(title: "", items: [])
+        if let section = item as? Section {
+            if let roots = section.treeRoots {
+                return roots.indices.contains(index) ? roots[index]
+                    : Section(title: "", items: [])
+            }
+            return section.items.indices.contains(index) ? section.items[index]
+                : Section(title: "", items: [])
         }
-        return section.items[index]
+        if let node = item as? TreeNode {
+            let kids = node.loadChildrenIfNeeded()
+            return kids.indices.contains(index) ? kids[index] : Section(title: "", items: [])
+        }
+        return Section(title: "", items: [])
     }
     func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
-        item is Section
+        if item is Section { return true }
+        // Report directories as expandable WITHOUT scanning, so the disclosure
+        // triangle appears immediately. If an expanded folder turns out to have
+        // no subfolders, NSOutlineView removes the triangle on its own.
+        if let node = item as? TreeNode { return node.isDirectory }
+        return false
     }
     func outlineView(_ outlineView: NSOutlineView, isGroupItem item: Any) -> Bool {
         item is Section
@@ -384,10 +652,9 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
         ThemedRowView()   // theme-accent selection pill (system theme → native)
     }
     func outlineViewSelectionDidChange(_ notification: Notification) {
-        let row = outline.selectedRow
-        guard row >= 0, let entry = outline.item(atRow: row) as? Entry else { return }
-        if selectedURL != entry.url {
-            onSelect?(entry.url)
+        guard let url = navigableURL(forRow: outline.selectedRow) else { return }
+        if selectedURL != url {
+            onSelect?(url)
         }
     }
 
@@ -414,7 +681,13 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
             view.textField?.textColor = sidebarSecondaryColor
             return view
         }
-        if let e = item as? Entry {
+        // Both flat shortcut Entries and folder-tree TreeNodes render the same
+        // icon + label row; pull the pair out so they share the cell.
+        let leaf: (icon: NSImage, title: String)?
+        if let e = item as? Entry { leaf = (e.icon, e.title) }
+        else if let n = item as? TreeNode { leaf = (n.icon, n.title) }
+        else { leaf = nil }
+        if let leaf {
             let id = NSUserInterfaceItemIdentifier("entry")
             let view = (outlineView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView) ?? {
                 let v = NSTableCellView()
@@ -440,13 +713,13 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
                 v.identifier = id
                 return v
             }()
-            let cellIcon = e.icon
+            let cellIcon = leaf.icon
             if cellIcon.isTemplate {
                 view.imageView?.image = cellIcon.tinted(sidebarPrimaryColor)
             } else {
                 view.imageView?.image = cellIcon
             }
-            view.textField?.stringValue = e.title
+            view.textField?.stringValue = leaf.title
             view.textField?.textColor = sidebarPrimaryColor
             return view
         }

--- a/Sources/FinderTwo/UI/SidebarController.swift
+++ b/Sources/FinderTwo/UI/SidebarController.swift
@@ -96,6 +96,36 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
     }
 
     private var sections: [Section] = []
+    /// Tags load asynchronously (Spotlight); cached here so section assembly stays
+    /// driven by `canonicalRank`, never by completion-handler timing.
+    private var tagsSection: Section?
+
+    /// Fixed display order for sidebar sections. The visible array is always
+    /// rebuilt from this rank, so two in-flight async loads (Tags vs the folder
+    /// tree) can finish in any order without changing section order or flickering.
+    private static func canonicalRank(of title: String) -> Int {
+        switch title {
+        case "Favorites":                           return 0
+        case "Locations":                           return 1
+        case "Smart Folders":                       return 2
+        case "Tags":                                return 3
+        case SidebarController.foldersSectionTitle: return 4   // "Folders" — always last
+        default:                                    return 99
+        }
+    }
+
+    /// Assemble `sections` in canonical order from the synchronous sections plus
+    /// the (optional) cached async Tags section. Idempotent and order-stable; the
+    /// Folders section is kept even though its `items` are empty (it carries the
+    /// expandable `treeRoots`).
+    private func applySections(base: [Section]) {
+        var all = base
+        if let tags = tagsSection { all.append(tags) }
+        sections = all
+            .filter { !$0.items.isEmpty || $0.title == SidebarController.foldersSectionTitle }
+            .sorted { SidebarController.canonicalRank(of: $0.title)
+                    < SidebarController.canonicalRank(of: $1.title) }
+    }
     /// Top-level roots of the folder tree (Home + mounted volumes). Kept around
     /// so their lazily-built children survive `reloadData` across bookmark/theme
     /// changes (rebuilding them would collapse the user's expanded folders).
@@ -529,17 +559,16 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
         let foldersSection = Section(title: SidebarController.foldersSectionTitle,
                                      items: [], treeRoots: treeRoots)
 
-        sections = [
+        applySections(base: [
             Section(title: "Favorites", items: favs),
             Section(title: "Locations", items: locations),
             Section(title: "Smart Folders", items: smartItems),
-        ].filter { !$0.items.isEmpty }
-        sections.append(foldersSection)
+            foldersSection,
+        ])
 
         // Populate Tags section asynchronously — Spotlight call.
         TagIndex.allTagSummaries { [weak self] summaries in
             guard let self else { return }
-            guard !summaries.isEmpty else { return }
             let tagItems = summaries.map { s -> Entry in
                 let img = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil)
                 let tinted = img?.tinted(s.tag.color.nsColor) ?? img ?? NSImage()
@@ -548,14 +577,13 @@ final class SidebarController: NSViewController, NSOutlineViewDataSource, NSOutl
                 return Entry(title: label, url: URL(fileURLWithPath: "/tag/\(s.tag.name)"),
                              icon: tinted)
             }
-            // Keep the folder tree last: drop Tags in just above it if present.
-            let tagSection = Section(title: "Tags", items: tagItems)
-            if let folderIdx = self.sections.firstIndex(where: {
-                $0.title == SidebarController.foldersSectionTitle }) {
-                self.sections.insert(tagSection, at: folderIdx)
-            } else {
-                self.sections.append(tagSection)
-            }
+            // Cache the Tags section (nil when there are no tags) and re-derive the
+            // ordered list. Its slot is fixed by canonicalRank, so it's correct no
+            // matter whether this Spotlight load or the folder-tree build finished
+            // first — and a later rebuild keeps Tags rather than flickering it out.
+            self.tagsSection = tagItems.isEmpty ? nil : Section(title: "Tags", items: tagItems)
+            let base = self.sections.filter { $0.title != "Tags" }
+            self.applySections(base: base)
             self.outline.reloadData()
             for s in self.sections { self.outline.expandItem(s) }
         }


### PR DESCRIPTION
## What

Adds a Windows Explorer-style expandable folder **tree** to the sidebar — the
#1 Explorer feature missing from Rascal. A new **Folders** section appears
beneath the existing flat sections (Favorites / Locations / Smart Folders /
Tags). Its top-level rows are your Home folder plus each mounted volume; every
folder shows a disclosure triangle and expands inline to reveal its
subfolders, recursively. Selecting or clicking a folder navigates the active
pane to it; the disclosure triangle (and `←` / `→`) collapses/expands.

## How

- **Where it lives:** `Sources/FinderTwo/UI/SidebarController.swift`, the
  existing `NSOutlineView` source-list controller. A new `TreeNode` reference
  type models tree rows; the `Folders` `Section` carries `treeRoots` (Home +
  browsable mounted volumes) built in `buildTreeRoots()`.
- **Lazy loading:** children are enumerated on demand in
  `TreeNode.loadChildrenIfNeeded()` using the existing fast scanner
  `FS/FastDirScan.swift` (subdirectories only, sorted case-insensitively,
  hidden folders gated on the global show-hidden default), then cached per
  node. `numberOfChildrenOfItem` triggers the scan only for items
  NSOutlineView is about to display, so collapsed/deep trees are never
  pre-scanned. `isItemExpandable` reports a directory as expandable *without*
  scanning, so the triangle shows instantly and NSOutlineView removes it itself
  if a folder turns out empty.
- **Edge cases:** a symlink-cycle guard tracks resolved ancestor paths and
  drops any symlinked directory that points back up the tree, so expansion
  can't recurse forever. Empty, permission-denied (`opendir` fails), and
  non-directory nodes all degrade to zero children without crashing.
- **Navigation/highlight:** clicking a tree folder calls the existing
  `onSelect` → active pane navigates; `highlight(url:)` re-selects an
  already-loaded tree node (never forcing a scan) so the row stays highlighted.
- **Context menu:** right-clicking a tree folder offers Open in New
  Tab/Window and Add/Remove from Sidebar.
- Tree expansion state is intentionally **not** persisted (restoring it would
  scan every saved path on launch, against the lazy design); the section
  headers still persist their expanded state via the existing autosave.

## Headless testing

Off-screen assertions were added to
`Sources/FinderTwo/Tests/TestRunner.swift` (`runSidebarFolderTreeTests`): a
node's children equal the subdirectories of a known temp dir; expansion is
lazy (not loaded before first access, loaded after); nested expansion
populates on demand; empty / file / permission-denied / symlink-cycle folders
never crash; and the live sidebar exposes a Folders section rooted at Home.
These build a `SidebarController` off-screen (same pattern as existing sidebar
tests) — no visible window, no focus taken.

**Note on this environment:** the full `smoketest.sh` / `guitest.sh` suites
could not be run to completion here because the sandbox SIGTERMs long-running
child processes after a wall-clock window (~30-40s) that is shorter than the
full suite. Up to the kill point every run showed **0 failures**, and a
`guitest.sh` run reached **104/105 passes** with the single failure being a
transient AppleScript `-1719` "process disappeared" / AX timeout (a different
random item each run), not a menu/shortcut regression — this change touches no
menu or action code. To verify the new logic directly I ran the folder-tree
assertions in isolation:

```
=== Rascal folder-tree tests (isolated) ===
  ✓ tree node is not loaded before expansion
  ✓ tree node loaded after first child access
  ✓ tree children are exactly the visible subdirectories (sorted, no files)
  ✓ tree children match the directory's actual subdirectory set
  ✓ nested tree node starts unloaded (lazy)
  ✓ expanding a nested node lists ITS subdirectories
  ✓ empty folder yields no children (no crash)
  ✓ file node yields no children (no crash)
  ✓ permission-denied folder degrades to no children (no crash)
  ✓ symlink-to-parent is dropped (cycle guard)
  ✓ live sidebar has a Folders section
  ✓ folder tree roots include the home folder

=== 12 passed, 0 failed ===
```

`./build.sh debug` compiles clean with **no new warnings**.

## What to check when testing headed

- The **Folders** section appears at the bottom of the sidebar with Home + your
  volumes, each with a disclosure triangle.
- Expanding a folder reveals its subfolders; deep/large folders expand snappily
  (lazy) and don't hitch the UI.
- Clicking a tree folder navigates the active pane; `←`/`→` collapse/expand the
  focused row.
- Re-run `./smoketest.sh` and `./guitest.sh` on your machine to confirm a clean
  pass (they should complete without the environment's process-kill
  truncation).
- Permission-denied folders (e.g. some system dirs without Full Disk Access)
  should just show no children rather than erroring.

## Deferred / coordination

- Persisting per-folder expansion across launches is deferred (correctness +
  speed prioritized, as the task allowed).
- **Merge note:** the sibling branch `feature/file-provider-cloud` also edits
  the sidebar; a merge reconciliation in `SidebarController.swift` may be
  needed.
