### PR TITLE
Multi-pane layouts (up to 4), resizable splitters, savable layout

### DIFF
--- a/Sources/FinderTwo/AppDelegate.swift
+++ b/Sources/FinderTwo/AppDelegate.swift
@@ -142,12 +142,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         saveSessionSnapshot()
     }
 
-    /// Capture the current frontmost window's layout into SessionStore. Called on
-    /// quit and whenever a window closes, so the latest layout is always saved
-    /// even if the app is force-quit later.
-    private func saveSessionSnapshot() {
-        let wc = currentBrowserWC() ?? windowControllers.last
-        SessionStore.save(wc?.sessionSnapshot())
+    /// True once a session snapshot has been committed for the current shutdown /
+    /// window-close, so the terminate path and the window-close path can't both
+    /// write (and clobber) the same key.
+    private var didSaveSessionSnapshot = false
+
+    /// Capture a specific window's layout into SessionStore. Called on quit and
+    /// whenever a window closes; coalesced so overlapping triggers write once. Pass
+    /// the closing window explicitly so we never snapshot a nil/torn-down window
+    /// (which would clear the key and wipe the just-saved layout).
+    private func saveSessionSnapshot(for wc: BrowserWindowController? = nil) {
+        guard !didSaveSessionSnapshot else { return }
+        guard let target = wc ?? currentBrowserWC() ?? windowControllers.last else { return }
+        let snap = target.sessionSnapshot()
+        // No usable layout to snapshot → leave whatever a previous save wrote intact
+        // rather than clearing the key.
+        guard let panes = snap["panes"] as? [Any], !panes.isEmpty else { return }
+        didSaveSessionSnapshot = true
+        SessionStore.save(snap)
     }
 
     // MARK: - Windows
@@ -182,7 +194,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             if let self, let wc {
                 // Snapshot the closing window's layout while it's still intact, so
                 // closing the last window (then quitting) still restores its panes.
-                if !isHeadless { SessionStore.save(wc.sessionSnapshot()) }
+                if !isHeadless { self.saveSessionSnapshot(for: wc) }
                 self.windowControllers.removeAll { $0 === wc }
             }
             if let token = box.token { NotificationCenter.default.removeObserver(token) }   // one-shot

--- a/Sources/FinderTwo/AppDelegate.swift
+++ b/Sources/FinderTwo/AppDelegate.swift
@@ -96,13 +96,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if let cliPath = AppDelegate.cliPath() {
             openNewBrowserWindow(at: URL(fileURLWithPath: cliPath))
         } else {
-            // Always open exactly one fresh window at the configured default
-            // location (home fallback). We deliberately do NOT reopen a previous
-            // multi-window session — relaunching gives a single clean window.
+            // Open exactly one window. We deliberately do NOT reopen a previous
+            // MULTI-window session (that's the classic duplicate-windows bug);
+            // instead, restore the last window's pane LAYOUT (pane count + each
+            // pane's tabs + divider positions) into that single window. Falls
+            // back to a fresh window at the default location when restore is off
+            // or no usable session was saved.
             let target = Settings.defaultLocation.url ?? FileManager.default.homeDirectoryForCurrentUser
             let dir = FileManager.default.fileExists(atPath: target.path)
                 ? target : FileManager.default.homeDirectoryForCurrentUser
-            openNewBrowserWindow(at: dir)
+            if Settings.restoreLastSession, let snap = SessionStore.load() {
+                let wc = BrowserWindowController(rootURL: dir)
+                wc.restoreFromSnapshot(snap)
+                finishOpening(wc)
+            } else {
+                openNewBrowserWindow(at: dir)
+            }
         }
         let isHeadless = ProcessInfo.processInfo.environment["FT_HEADLESS_TESTING"] == "1"
         if !isHeadless {
@@ -124,6 +133,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { false }
+
+    /// Persist the frontmost (else most-recent) window's pane layout as the
+    /// last session so the next launch can restore it. Skipped in headless/test
+    /// runs so an off-screen harness window never overwrites the real session.
+    func applicationWillTerminate(_ notification: Notification) {
+        guard ProcessInfo.processInfo.environment["FT_HEADLESS_TESTING"] != "1" else { return }
+        saveSessionSnapshot()
+    }
+
+    /// Capture the current frontmost window's layout into SessionStore. Called on
+    /// quit and whenever a window closes, so the latest layout is always saved
+    /// even if the app is force-quit later.
+    private func saveSessionSnapshot() {
+        let wc = currentBrowserWC() ?? windowControllers.last
+        SessionStore.save(wc?.sessionSnapshot())
+    }
 
     // MARK: - Windows
 
@@ -154,7 +179,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         box.token = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification, object: wc.window, queue: .main
         ) { [weak self, weak wc] _ in
-            if let self, let wc { self.windowControllers.removeAll { $0 === wc } }
+            if let self, let wc {
+                // Snapshot the closing window's layout while it's still intact, so
+                // closing the last window (then quitting) still restores its panes.
+                if !isHeadless { SessionStore.save(wc.sessionSnapshot()) }
+                self.windowControllers.removeAll { $0 === wc }
+            }
             if let token = box.token { NotificationCenter.default.removeObserver(token) }   // one-shot
         }
     }

--- a/Sources/FinderTwo/Model/Settings.swift
+++ b/Sources/FinderTwo/Model/Settings.swift
@@ -237,6 +237,14 @@ enum Settings {
         set { d.set(newValue, forKey: "FinderTwo.doubleClickFolderOpensNewTab"); notify() }
     }
 
+    /// Restore the last window's pane layout (pane count, each pane's tabs, and
+    /// the divider positions) on the next launch. On by default; when off, each
+    /// launch opens a single fresh window at the default location.
+    static var restoreLastSession: Bool {
+        get { d.object(forKey: "FinderTwo.restoreLastSession") as? Bool ?? true }
+        set { d.set(newValue, forKey: "FinderTwo.restoreLastSession"); notify() }
+    }
+
     // MARK: Notifications
 
     private static func notify() {

--- a/Sources/FinderTwo/Model/Workspaces.swift
+++ b/Sources/FinderTwo/Model/Workspaces.swift
@@ -50,6 +50,42 @@ enum WorkspaceStore {
     }
 }
 
+/// The auto-saved last-session layout (one window's pane/tab/divider state).
+/// Unlike `WorkspaceStore` this is implicit: it's written when the app quits or
+/// the last window closes, and restored into the first window on the next
+/// launch (gated by `Settings.restoreLastSession`). Stored as a plain snapshot
+/// dictionary — the same shape `BrowserWindowController.sessionSnapshot()`
+/// returns — serialized to JSON so it survives relaunch.
+enum SessionStore {
+    private static let key = "FinderTwo.session.v1"
+
+    /// Persist a window snapshot as the last session. A nil/empty snapshot
+    /// clears it (so a quit with no usable window doesn't strand stale state).
+    static func save(_ snapshot: [String: Any]?) {
+        guard let snapshot,
+              let panes = snapshot["panes"] as? [Any], !panes.isEmpty,
+              let data = try? JSONSerialization.data(withJSONObject: snapshot) else {
+            UserDefaults.standard.removeObject(forKey: key)
+            return
+        }
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    /// The last saved session snapshot, or nil if none/invalid.
+    static func load() -> [String: Any]? {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let panes = obj["panes"] as? [Any], !panes.isEmpty else {
+            return nil
+        }
+        return obj
+    }
+
+    static func clear() {
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}
+
 enum WorkspaceController {
     static func promptSave(in wc: BrowserWindowController) {
         guard let win = wc.window else { return }

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -596,6 +596,79 @@ final class TestRunner {
         testWC.window?.close()
         restoredWC.window?.close()
 
+        // --- T24b: multi-pane layout round-trip (pane count + divider sizes) ---
+        // Build a 3-pane window, give it a concrete size, drag the dividers to
+        // custom positions, snapshot it, then restore into a fresh window and
+        // verify the pane count and the divider fractions both survive.
+        let mpRoot = sandbox.appendingPathComponent("subdir")
+        let mpWC = BrowserWindowController(rootURL: mpRoot)
+        mpWC.window?.setContentSize(NSSize(width: 1200, height: 700))
+        mpWC.testAddPane()                      // 2 panes
+        mpWC.testActivePane?.navigate(to: sandbox)
+        mpWC.testAddPane()                      // 3 panes
+        assert("multi-pane layout starts at 3 panes", mpWC.testPaneCount == 3, "panes=\(mpWC.testPaneCount)")
+        mpWC.window?.layoutIfNeeded()
+        wait(0.05)
+        // Drag dividers to deliberately-uneven positions (defaults are even).
+        let mpSplit = mpWC.testPanesSplitView
+        if mpSplit.bounds.width > 1 {
+            mpSplit.setPosition(mpSplit.bounds.width * 0.30, ofDividerAt: 0)
+            mpSplit.setPosition(mpSplit.bounds.width * 0.60, ofDividerAt: 1)
+            mpSplit.layoutSubtreeIfNeeded()
+        }
+        let mpSnap = mpWC.sessionSnapshot()
+        let savedFractions = mpSnap["dividers"] as? [Double] ?? []
+        assert("snapshot captures one divider fraction per gap (3 panes → 2)",
+               savedFractions.count == 2, "got=\(savedFractions)")
+
+        // Round-trip the snapshot through JSON (the real persistence path) and
+        // confirm the fractions are preserved verbatim.
+        let mpData = try? JSONSerialization.data(withJSONObject: mpSnap)
+        let mpDecoded = mpData.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        let decodedFractions = (mpDecoded?["dividers"] as? [Double]) ?? []
+        assert("divider fractions survive JSON round-trip",
+               decodedFractions == savedFractions, "got=\(decodedFractions) expected=\(savedFractions)")
+
+        // Restore into a brand-new window and check the layout rebuilds.
+        let mpRestored = BrowserWindowController(rootURL: FileManager.default.homeDirectoryForCurrentUser)
+        mpRestored.window?.setContentSize(NSSize(width: 1200, height: 700))
+        mpRestored.restoreFromSnapshot(mpSnap)
+        assert("restored window rebuilds all 3 panes", mpRestored.testPaneCount == 3,
+               "panes=\(mpRestored.testPaneCount)")
+        // The restore re-applies divider fractions on a deferred layout pass; the
+        // re-snapshot must carry the same number of dividers (and, once laid out,
+        // the same fractions within tolerance).
+        mpRestored.window?.layoutIfNeeded()
+        wait(0.1)
+        let reFractions = (mpRestored.sessionSnapshot()["dividers"] as? [Double]) ?? []
+        assert("restored layout re-exposes 2 divider fractions",
+               reFractions.count == 2, "got=\(reFractions)")
+        if !savedFractions.isEmpty && !reFractions.isEmpty && mpSplit.bounds.width > 1 {
+            // Geometry assertion — only meaningful once both split views actually
+            // laid out. Tolerance covers minimum-thickness clamping at small sizes.
+            let close = zip(savedFractions, reFractions).allSatisfy { abs($0 - $1) < 0.08 }
+            assert("restored divider positions match the saved layout", close,
+                   "saved=\(savedFractions) restored=\(reFractions)")
+        }
+        mpWC.window?.close()
+        mpRestored.window?.close()
+
+        // --- T24c: SessionStore (auto last-session) save / load round-trip ---
+        let sessWC = BrowserWindowController(rootURL: sandbox)
+        sessWC.testAddPane()
+        let sessSnap = sessWC.sessionSnapshot()
+        SessionStore.save(sessSnap)
+        let sessLoaded = SessionStore.load()
+        assert("SessionStore persists a saved session", sessLoaded != nil, "nil")
+        let sessLoadedPaneCount = (sessLoaded?["panes"] as? [Any])?.count ?? 0
+        assert("SessionStore round-trips the pane set", sessLoadedPaneCount == 2, "got=\(sessLoadedPaneCount)")
+        SessionStore.clear()
+        assert("SessionStore.clear removes the saved session", SessionStore.load() == nil, "still present")
+        // An empty/paneless snapshot must clear rather than persist garbage.
+        SessionStore.save(["panes": [[String: Any]]()])
+        assert("SessionStore ignores an empty snapshot", SessionStore.load() == nil, "stored empty")
+        sessWC.window?.close()
+
         // --- T25: Theme switching ---
         let initialTheme = ThemeManager.shared.current.id
         ThemeManager.shared.setTheme(id: "midnight")

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -3592,6 +3592,10 @@ final class TestRunner {
             wcXp.moveToOtherPane(nil)
             let moved = waitUntil(3) { fm.fileExists(atPath: xR.appendingPathComponent("doc.txt").path) && !fm.fileExists(atPath: xfile.path) }
             assert("F6 move-to-other-pane lands in the +1 pane (move)", moved, "not moved to R")
+            // The queue records undo from the worker just AFTER the moved file
+            // becomes observable — wait for the log too, or slow machines (VMs,
+            // loaded CI hosts) can check canUndo inside that gap and flake.
+            _ = waitUntil(3) { FileActionLog.shared.canUndo }
             assert("cross-pane move records undo", FileActionLog.shared.canUndo, "no undo")
             wcXp.fileUndo(nil); wait(0.3)
             assert("undo of a cross-pane move restores the source pane's file",

--- a/Sources/FinderTwo/UI/SettingsPanes.swift
+++ b/Sources/FinderTwo/UI/SettingsPanes.swift
@@ -505,6 +505,11 @@ final class AdvancedPane: SettingsPane {
         rememberViews.state = Settings.rememberFolderViews ? .on : .off
         addRow("", rememberViews)
 
+        let restoreSession = NSButton(checkboxWithTitle: "Restore last window layout on launch (panes, tabs, divider sizes)",
+                                      target: self, action: #selector(restoreSessionChanged(_:)))
+        restoreSession.state = Settings.restoreLastSession ? .on : .off
+        addRow("Layout:", restoreSession)
+
         let confirmTrash = NSButton(checkboxWithTitle: "Warn before moving items to Trash",
                                     target: self, action: #selector(confirmTrashChanged(_:)))
         confirmTrash.state = Settings.confirmTrash ? .on : .off
@@ -532,6 +537,7 @@ final class AdvancedPane: SettingsPane {
     @objc private func calcSizesChanged(_ s: NSButton) { Settings.calculateFolderSizes = s.state == .on }
     @objc private func confirmTrashChanged(_ s: NSButton) { Settings.confirmTrash = s.state == .on }
     @objc private func rememberViewsChanged(_ s: NSButton) { Settings.rememberFolderViews = s.state == .on }
+    @objc private func restoreSessionChanged(_ s: NSButton) { Settings.restoreLastSession = s.state == .on }
 
     @objc private func vimChanged(_ s: NSButton) { VimMode.shared.setEnabled(s.state == .on) }
 

--- a/Sources/FinderTwo/Window/BrowserWindowController.swift
+++ b/Sources/FinderTwo/Window/BrowserWindowController.swift
@@ -773,6 +773,8 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
     var testAllPanes: [PaneController] { panesContainer.allPanes }
     var testActivePane: PaneController? { panesContainer.activePane }
     var testPaneCount: Int { panesContainer.testPaneCount }
+    /// The panes' NSSplitView, so tests can drag dividers and read positions.
+    var testPanesSplitView: NSSplitView { panesContainer.splitView }
     func testToggleExtraPane() { panesContainer.toggleExtraPane() }
     func testAddPane() { panesContainer.addExtraPane() }
     func testCloseActivePane() { panesContainer.closeActivePane() }
@@ -781,7 +783,9 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
 
     func sessionSnapshot() -> [String: Any] {
         let panes = panesContainer.allPanes.map { $0.sessionSnapshot() }
-        return ["panes": panes]
+        // Persist the divider positions (as width fractions) alongside the panes
+        // so a restored multi-pane window keeps the user's custom column widths.
+        return ["panes": panes, "dividers": panesContainer.dividerFractions()]
     }
     func restoreFromSnapshot(_ snap: [String: Any]) {
         guard let panes = snap["panes"] as? [[String: Any]], !panes.isEmpty else { return }
@@ -792,6 +796,10 @@ final class BrowserWindowController: NSWindowController, NSWindowDelegate, Theme
         panesContainer.allPanes.first?.restoreFromSnapshot(panes[0])
         for p in panes.dropFirst() {
             panesContainer.addPaneForRestore(snap: p)
+        }
+        // Re-apply saved divider positions once the rebuilt panes lay out.
+        if let dividers = snap["dividers"] as? [Double] {
+            panesContainer.applyDividerFractions(dividers)
         }
     }
 }

--- a/Sources/FinderTwo/Window/PanesContainerController.swift
+++ b/Sources/FinderTwo/Window/PanesContainerController.swift
@@ -168,6 +168,67 @@ final class PanesContainerController: NSSplitViewController {
         }
     }
 
+    // MARK: Divider layout (save / restore)
+
+    /// Capture each divider's position as a FRACTION of the split view's content
+    /// width (0…1), so the layout restores proportionally regardless of the
+    /// window size at restore time. With N panes there are N-1 dividers; an
+    /// empty array means "no custom sizing" (panes fall back to equal widths).
+    func dividerFractions() -> [Double] {
+        let count = splitView.arrangedSubviews.count
+        guard count > 1 else { return [] }
+        let total = splitView.isVertical ? splitView.bounds.width : splitView.bounds.height
+        guard total > 1 else { return [] }
+        var fractions: [Double] = []
+        // The position of divider i is the trailing edge of arranged subview i.
+        var running: CGFloat = 0
+        for i in 0..<(count - 1) {
+            let v = splitView.arrangedSubviews[i]
+            running += splitView.isVertical ? v.frame.width : v.frame.height
+            fractions.append(Double(max(0, min(1, running / total))))
+        }
+        return fractions
+    }
+
+    /// Apply previously captured divider fractions (see `dividerFractions`).
+    /// Runs after the next layout pass so the split view already has its final
+    /// bounds — setting positions against a zero-width split view would clamp
+    /// everything to the minimum thickness.
+    func applyDividerFractions(_ fractions: [Double]) {
+        guard !fractions.isEmpty else { return }
+        pendingDividerFractions = fractions
+        view.needsLayout = true
+        // Defer to the next runloop turn: during launch/restore the split view's
+        // bounds aren't established until the window has been sized, and tests
+        // build controllers without ever showing the window.
+        DispatchQueue.main.async { [weak self] in self?.applyPendingDividerFractions() }
+    }
+
+    /// Divider fractions captured from a snapshot, waiting for the split view to
+    /// gain non-zero bounds before they can be applied.
+    private var pendingDividerFractions: [Double]?
+
+    private func applyPendingDividerFractions() {
+        guard let fractions = pendingDividerFractions else { return }
+        let count = splitView.arrangedSubviews.count
+        // Need one fraction per divider; bail (and keep them pending) until the
+        // pane set and the split view bounds are both ready.
+        guard count > 1, fractions.count == count - 1 else { return }
+        let total = splitView.isVertical ? splitView.bounds.width : splitView.bounds.height
+        guard total > 1 else { return }   // not laid out yet — try again after layout
+        view.layoutSubtreeIfNeeded()
+        for (i, f) in fractions.enumerated() {
+            splitView.setPosition(CGFloat(f) * total, ofDividerAt: i)
+        }
+        pendingDividerFractions = nil
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        // Apply any pending restore once the split view finally has real bounds.
+        applyPendingDividerFractions()
+    }
+
     /// Move keyboard focus to the next/previous pane (wraps). No-op with one pane.
     func focusPane(by delta: Int) {
         guard panes.count > 1 else { return }

--- a/Sources/FinderTwo/Window/PanesContainerController.swift
+++ b/Sources/FinderTwo/Window/PanesContainerController.swift
@@ -207,8 +207,13 @@ final class PanesContainerController: NSSplitViewController {
     /// Divider fractions captured from a snapshot, waiting for the split view to
     /// gain non-zero bounds before they can be applied.
     private var pendingDividerFractions: [Double]?
+    /// Re-entrancy guard: setPosition() dirties layout, so applying fractions can
+    /// itself trigger another viewDidLayout. Without this, viewDidLayout →
+    /// applyPendingDividerFractions → setPosition → viewDidLayout … can loop.
+    private var isApplyingDividerFractions = false
 
     private func applyPendingDividerFractions() {
+        guard !isApplyingDividerFractions else { return }
         guard let fractions = pendingDividerFractions else { return }
         let count = splitView.arrangedSubviews.count
         // Need one fraction per divider; bail (and keep them pending) until the
@@ -216,11 +221,17 @@ final class PanesContainerController: NSSplitViewController {
         guard count > 1, fractions.count == count - 1 else { return }
         let total = splitView.isVertical ? splitView.bounds.width : splitView.bounds.height
         guard total > 1 else { return }   // not laid out yet — try again after layout
-        view.layoutSubtreeIfNeeded()
+        isApplyingDividerFractions = true
+        defer { isApplyingDividerFractions = false }
+        // Clear FIRST so this is strictly one-shot: even if setPosition re-enters
+        // viewDidLayout synchronously, there's nothing left pending to re-apply.
+        pendingDividerFractions = nil
+        // Don't force layout here — we may be inside a layout pass (viewDidLayout);
+        // the guards above already confirm the split view has real bounds, which is
+        // all setPosition needs.
         for (i, f) in fractions.enumerated() {
             splitView.setPosition(CGFloat(f) * total, ofDividerAt: i)
         }
-        pendingDividerFractions = nil
     }
 
     override func viewDidLayout() {


### PR DESCRIPTION
## What

Completes Rascal's multi-pane support: panes can be added/removed up to 4
in a single window (already wired), divider sizes are now **persisted**,
and the **last window layout is restored on relaunch**.

- **N panes (≥4):** `Add Pane` (⌃⌘\) / `Close Pane` actions and 1–4 panes
  in a vertical `NSSplitView` with draggable dividers were already present
  — this PR keeps them and makes the layout durable.
- **Resizable splitters with custom sizes:** divider positions are saved
  as width **fractions** in the window snapshot, so a restored multi-pane
  window keeps the user's column widths regardless of window size.
- **Save/restore the layout:** a new `SessionStore` auto-saves the
  frontmost window's pane count + each pane's tabs + divider positions and
  restores them into the single window opened at launch.

## How

- `PanesContainerController`: `dividerFractions()` captures divider
  positions as fractions of the split view's content width;
  `applyDividerFractions(_:)` re-applies them, deferring to the next layout
  pass (and `viewDidLayout`) because the split view's bounds aren't
  established until the window is sized (true during launch restore and in
  headless tests).
- `BrowserWindowController.sessionSnapshot()/restoreFromSnapshot()` now
  carry a `"dividers"` array alongside the existing `"panes"`.
- `SessionStore` (in `Workspaces.swift`, sibling to `WorkspaceStore`)
  persists one window snapshot to `UserDefaults` (`FinderTwo.session.v1`),
  serialized as JSON. Written on `applicationWillTerminate` and on window
  close; read at launch into the one window we open. Gated by a new
  `Settings.restoreLastSession` pref (default ON), exposed as a checkbox in
  the Advanced settings pane. Headless/test runs never overwrite the real
  session.

## Headless testing

`./build.sh debug` — clean, no warnings.

`./smoketest.sh` — **559 passed, 0 failed.** New assertions:

```
✓ multi-pane layout starts at 3 panes
✓ snapshot captures one divider fraction per gap (3 panes → 2)
✓ divider fractions survive JSON round-trip
✓ restored window rebuilds all 3 panes
✓ restored layout re-exposes 2 divider fractions
✓ restored divider positions match the saved layout
✓ SessionStore persists a saved session
✓ SessionStore round-trips the pane set
✓ SessionStore.clear removes the saved session
✓ SessionStore ignores an empty snapshot
```

(Existing 4-pane add/cap/close and pane-focus tests continue to pass.)

`./guitest.sh` — **0 failures** (menu/shortcut AX audit). Add Pane / Close
Pane / pane-focus items remain registered in the View menu and palette.

## What to check when testing headed

- Open Extra Pane (⌘\), then Add Pane (⌃⌘\) up to 4; drag the dividers to
  uneven widths.
- Quit and relaunch: the pane count, each pane's folder/tabs, and the
  divider widths should come back.
- Toggle Settings → Advanced → "Restore last window layout on launch" off,
  relaunch: a single fresh window at the default location.
- Close a multi-pane window, reopen the app: layout restores from the
  closed window.

## Deferred

- **Named-workspaces UI is unchanged** (already shipped via `WorkspaceStore`
  / Save Workspace… / Open Workspace…). This PR adds the *implicit*
  last-session restore; it does not add new named-workspace UI.
- Divider positions restore proportionally (as fractions). They are not
  re-clamped if the saved layout came from a much wider window and a pane
  would fall below its 280pt minimum — AppKit clamps to the minimum in that
  case, which is acceptable but worth a glance in the headed test at very
  small window sizes.
