### PR TITLE
Declutter menus; gate developer actions

### DIFF
--- a/Sources/FinderTwo/AppDelegate.swift
+++ b/Sources/FinderTwo/AppDelegate.swift
@@ -249,14 +249,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         fileMenu.addItem(NSMenuItem.separator())
         fileMenu.addItem(routed("file.copy-path"))
         fileMenu.addItem(routed("file.open-in-terminal"))
-        fileMenu.addItem(routed("project.open-editor", title: "Open in Editor"))
+        // Developer-only commands appear inline only when developer mode is on;
+        // otherwise they live under the Go ▸ Developer submenu + the palette.
+        if Settings.developerMode {
+            fileMenu.addItem(routed("project.open-editor", title: "Open in Editor"))
+            fileMenu.addItem(routed("git.view-diffs"))
+        }
         fileMenu.addItem(NSMenuItem.separator())
-        fileMenu.addItem(routed("tool.browse-archive"))
-        fileMenu.addItem(routed("tool.folder-sync"))
-        fileMenu.addItem(routed("tool.analyze-disk"))
-        fileMenu.addItem(routed("tool.find-duplicates"))
-        fileMenu.addItem(routed("tool.compare-files"))
-        fileMenu.addItem(routed("tool.uninstall-app"))
+        // Less-frequent utilities tucked into a Tools submenu to keep File lean.
+        let toolsItem = NSMenuItem(title: "Tools", action: nil, keyEquivalent: "")
+        let toolsMenu = NSMenu(title: "Tools")
+        toolsMenu.addItem(routed("tool.browse-archive"))
+        toolsMenu.addItem(routed("tool.folder-sync"))
+        toolsMenu.addItem(routed("tool.analyze-disk"))
+        toolsMenu.addItem(routed("tool.find-duplicates"))
+        toolsMenu.addItem(routed("tool.compare-files"))
+        toolsMenu.addItem(routed("tool.uninstall-app"))
+        toolsItem.submenu = toolsMenu
+        fileMenu.addItem(toolsItem)
         fileMenu.addItem(NSMenuItem.separator())
         fileMenu.addItem(routed("file.trash"))
         fileMenu.addItem(routed("file.delete-immediately"))
@@ -309,15 +319,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let hiddenItem = routed("view.toggle-hidden", title: "Show Hidden Files")
         viewMenu.addItem(hiddenItem); chromeHiddenItem = hiddenItem
         viewMenu.addItem(NSMenuItem.separator())
+        // Keep the headline split-pane toggle (⌘\) at the top level; corral the
+        // rest of the pane-management commands into a Panes submenu.
         viewMenu.addItem(routed("pane.toggle-extra", title: "Open Extra Pane"))
-        viewMenu.addItem(routed("pane.add"))
-        viewMenu.addItem(routed("pane.close"))
-        viewMenu.addItem(routed("pane.focus-next"))
-        viewMenu.addItem(routed("pane.focus-prev"))
-        viewMenu.addItem(routed("pane.copy-to-other"))
-        viewMenu.addItem(routed("pane.move-to-other"))
+        let panesItem = NSMenuItem(title: "Panes", action: nil, keyEquivalent: "")
+        let panesMenu = NSMenu(title: "Panes")
+        panesMenu.addItem(routed("pane.add"))
+        panesMenu.addItem(routed("pane.close"))
+        panesMenu.addItem(routed("pane.focus-next"))
+        panesMenu.addItem(routed("pane.focus-prev"))
+        panesMenu.addItem(routed("pane.copy-to-other"))
+        panesMenu.addItem(routed("pane.move-to-other"))
         let syncItem = routed("pane.sync-browsing")
-        viewMenu.addItem(syncItem); chromeSyncBrowsingItem = syncItem
+        panesMenu.addItem(syncItem); chromeSyncBrowsingItem = syncItem
+        panesItem.submenu = panesMenu
+        viewMenu.addItem(panesItem)
         viewMenu.addItem(NSMenuItem.separator())
         viewMenu.addItem(routed("view.toggle-sidebar"))
         viewMenu.addItem(routed("view.toggle-statusbar"))
@@ -325,11 +341,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         viewMenu.addItem(routed("view.calculate-sizes"))
         viewMenu.addItem(routed("view.type-to-select"))
         viewMenu.addItem(NSMenuItem.separator())
-        viewMenu.addItem(routed("panel.preview"))
-        viewMenu.addItem(routed("panel.terminal"))
-        viewMenu.addItem(routed("panel.notes"))
-        viewMenu.addItem(routed("panel.transfers"))
-        viewMenu.addItem(routed("panel.shelf"))
+        // Panels (drawers + overlays) grouped together to slim the View menu.
+        let panelsItem = NSMenuItem(title: "Panels", action: nil, keyEquivalent: "")
+        let panelsMenu = NSMenu(title: "Panels")
+        panelsMenu.addItem(routed("panel.preview"))
+        panelsMenu.addItem(routed("panel.terminal"))
+        panelsMenu.addItem(routed("panel.notes"))
+        panelsMenu.addItem(routed("panel.transfers"))
+        panelsMenu.addItem(routed("panel.shelf"))
+        panelsItem.submenu = panelsMenu
+        viewMenu.addItem(panelsItem)
         viewMenu.addItem(NSMenuItem.separator())
         let showHotbar = NSMenuItem(title: "Show Hotbar",
                                     action: #selector(toggleHotbarMenu(_:)), keyEquivalent: "b")
@@ -368,9 +389,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         goMenu.addItem(NSMenuItem.separator())
         goMenu.addItem(routed("nav.goto", title: "Go to Folder…"))
         goMenu.addItem(routed("nav.home", title: "Home"))
-        goMenu.addItem(routed("project.jump-root", title: "Jump to Project Root"))
+        if Settings.developerMode {
+            // Inline when developer mode is on; otherwise these live in the
+            // Developer submenu added below.
+            goMenu.addItem(routed("project.jump-root", title: "Jump to Project Root"))
+        }
         goMenu.addItem(routed("net.connect-server", title: "Connect to Server…"))
         goMenu.addItem(routed("net.mount-volume", title: "Mount Network Volume…"))
+        if !Settings.developerMode {
+            // Developer-oriented commands kept out of the default menus; still
+            // fully reachable here and in the command palette.
+            goMenu.addItem(NSMenuItem.separator())
+            let devItem = NSMenuItem(title: "Developer", action: nil, keyEquivalent: "")
+            let devMenu = NSMenu(title: "Developer")
+            devMenu.addItem(routed("project.jump-root", title: "Jump to Project Root"))
+            devMenu.addItem(routed("project.open-editor", title: "Open in Editor"))
+            devMenu.addItem(routed("git.view-diffs"))
+            devItem.submenu = devMenu
+            goMenu.addItem(devItem)
+        }
         goMenu.addItem(NSMenuItem.separator())
         let goHome = FileManager.default.homeDirectoryForCurrentUser.path
         func goItem(_ title: String, _ path: String, _ key: String = "", _ mods: NSEvent.ModifierFlags = []) {

--- a/Sources/FinderTwo/Model/Actions.swift
+++ b/Sources/FinderTwo/Model/Actions.swift
@@ -20,8 +20,28 @@ struct Action {
     /// Users may override via the shortcut editor; the menu rebuilds from
     /// the effective shortcut.
     let defaultShortcut: KeyShortcut?
+    /// Programmer-oriented command (git, project root, open-in-editor, …).
+    /// Kept out of the default menus and tucked under a "Developer" submenu
+    /// unless `Settings.developerMode` is on. Always reachable in the palette.
+    let isDeveloper: Bool
     /// Body of the action. Receives the active BrowserWindowController.
     let perform: (BrowserWindowController) -> Void
+
+    init(id: String,
+         title: String,
+         category: Category,
+         icon: String?,
+         defaultShortcut: KeyShortcut?,
+         isDeveloper: Bool = false,
+         perform: @escaping (BrowserWindowController) -> Void) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.icon = icon
+        self.defaultShortcut = defaultShortcut
+        self.isDeveloper = isDeveloper
+        self.perform = perform
+    }
 
     enum Category: String, CaseIterable {
         case navigation = "Navigation"
@@ -100,19 +120,22 @@ enum ActionRegistry {
               title: "Jump to Project Root",
               category: .navigation,
               icon: "arrow.up.to.line.circle",
-              defaultShortcut: KeyShortcut("r", [.command, .control])) { $0.jumpToProjectRoot(nil) },
+              defaultShortcut: KeyShortcut("r", [.command, .control]),
+              isDeveloper: true) { $0.jumpToProjectRoot(nil) },
         .init(id: "project.open-editor",
               title: "Open in Editor",
               category: .navigation,
               icon: "chevron.left.forwardslash.chevron.right",
-              defaultShortcut: KeyShortcut("o", [.command, .shift])) { $0.openInEditor(nil) },
+              defaultShortcut: KeyShortcut("o", [.command, .shift]),
+              isDeveloper: true) { $0.openInEditor(nil) },
 
         // -------- File --------
         .init(id: "git.view-diffs",
               title: "View Git Diffs",
               category: .file,
               icon: "arrow.triangle.branch",
-              defaultShortcut: nil) { $0.viewGitDiffs(nil) },
+              defaultShortcut: nil,
+              isDeveloper: true) { $0.viewGitDiffs(nil) },
         .init(id: "file.new-folder",
               title: "New Folder",
               category: .file,

--- a/Sources/FinderTwo/Model/Settings.swift
+++ b/Sources/FinderTwo/Model/Settings.swift
@@ -207,6 +207,15 @@ enum Settings {
         set { d.set(newValue, forKey: "FinderTwo.showGitBranchInStatusBar"); notify() }
     }
 
+    /// Surface programmer-oriented commands (View Git Diffs, Jump to Project
+    /// Root, Open in Editor) directly in the menus. Off by default — those
+    /// actions live under a "Developer" submenu and the command palette so the
+    /// default menus stay lean for general users.
+    static var developerMode: Bool {
+        get { d.object(forKey: "FinderTwo.developerMode") as? Bool ?? false }
+        set { d.set(newValue, forKey: "FinderTwo.developerMode"); notify() }
+    }
+
     static var terminalShell: String {
         // Fall back to a sane default for a missing, empty, whitespace-only, or
         // non-executable value, so a bad custom path can't make every terminal
@@ -258,6 +267,7 @@ enum Settings {
                     "FinderTwo.springLoadedFolders", "FinderTwo.springLoadDelay",
                     "FinderTwo.useGroups",
                     "FinderTwo.gitIntegrationEnabled", "FinderTwo.showGitBranchInStatusBar",
+                    "FinderTwo.developerMode",
                     "FinderTwo.terminalShell", "FinderTwo.alwaysShowTabBar",
                     "FinderTwo.alternatingRows", "FinderTwo.doubleClickFolderOpensNewTab"] {
             d.removeObject(forKey: key)

--- a/Sources/FinderTwo/UI/SettingsPanes.swift
+++ b/Sources/FinderTwo/UI/SettingsPanes.swift
@@ -415,6 +415,18 @@ final class DeveloperPane: SettingsPane {
     private let customShellField = NSTextField()
 
     override func build() {
+        let devMode = NSButton(checkboxWithTitle: "Show developer commands in menus",
+                               target: self, action: #selector(devModeChanged(_:)))
+        devMode.state = Settings.developerMode ? .on : .off
+        addRow("Developer:", devMode)
+
+        let devHint = NSTextField(wrappingLabelWithString:
+            "Surfaces View Git Diffs, Jump to Project Root, and Open in Editor directly in the menus. When off, they stay under the Developer submenu and the command palette.")
+        devHint.font = NSFont.systemFont(ofSize: 11)
+        devHint.textColor = .tertiaryLabelColor
+        devHint.preferredMaxLayoutWidth = 380
+        addRow("", devHint)
+
         let gitEnabled = NSButton(checkboxWithTitle: "Enable Git integration (status & badges)",
                                   target: self, action: #selector(gitEnabledChanged(_:)))
         gitEnabled.state = Settings.gitIntegrationEnabled ? .on : .off
@@ -460,6 +472,12 @@ final class DeveloperPane: SettingsPane {
         addRow("Terminal shell:", shellStack)
     }
 
+    @objc private func devModeChanged(_ s: NSButton) {
+        Settings.developerMode = s.state == .on
+        // Rebuild the menu bar so the Developer-gated items move in/out of the
+        // default menus immediately (reuses the menu's existing rebuild hook).
+        NotificationCenter.default.post(name: ActionRegistry.shortcutsDidChange, object: nil)
+    }
     @objc private func gitEnabledChanged(_ s: NSButton) { Settings.gitIntegrationEnabled = s.state == .on }
     @objc private func gitBranchChanged(_ s: NSButton) { Settings.showGitBranchInStatusBar = s.state == .on }
 

--- a/guitest.sh
+++ b/guitest.sh
@@ -78,9 +78,7 @@ declare -a EXPECT=(
     "File|Search File Contents…"
     "File|Copy Path"
     "File|Open in Terminal"
-    "File|Find Duplicate Files…"
-    "File|Compare Two Files…"
-    "File|Open in Editor"
+    "File|Tools"
     "Edit|Cut"
     "Edit|Copy"
     "Edit|Paste"
@@ -96,6 +94,8 @@ declare -a EXPECT=(
     "View|as Gallery"
     "View|Show Hidden Files"
     "View|Open Extra Pane"
+    "View|Panes"
+    "View|Panels"
     "Go|Back"
     "Go|Forward"
     "Go|Enclosing Folder"
@@ -103,13 +103,8 @@ declare -a EXPECT=(
     "Go|Open"
     "Go|Go to Folder…"
     "Go|Home"
-    "Go|Jump to Project Root"
-    "View|Focus Next Pane"
-    "View|Focus Previous Pane"
-    "View|Synchronized Browsing"
+    "Go|Developer"
     "View|Use Groups"
-    "View|Transfer Activity"
-    "View|Drop Stack"
     "View|Theme"
     "Window|Minimize"
     "Window|Zoom"
@@ -126,24 +121,65 @@ for spec in "${EXPECT[@]}"; do
     [[ "$out" == "true" ]] && pass "$menu → $item" || fail "$menu → $item MISSING"
 done
 
+# -- Phase 2b: items now nested under submenus ------------------------------
+# After the menu declutter, less-frequent and developer-oriented commands live
+# in submenus (File ▸ Tools, View ▸ Panes/Panels, Go ▸ Developer). Verify each
+# stays reachable at its submenu path. Format: "Menu|Submenu|Item".
+echo "=== Phase 2b: submenu items ==="
+declare -a EXPECT_SUB=(
+    "File|Tools|Find Duplicate Files…"
+    "File|Tools|Compare Two Files…"
+    "File|Tools|Analyze Disk Usage…"
+    "File|Tools|Browse Archive…"
+    "File|Tools|Sync Folder…"
+    "File|Tools|Uninstall App…"
+    "View|Panes|Add Pane"
+    "View|Panes|Close Pane"
+    "View|Panes|Focus Next Pane"
+    "View|Panes|Focus Previous Pane"
+    "View|Panes|Synchronized Browsing"
+    "View|Panels|Show Preview"
+    "View|Panels|Toggle Terminal"
+    "View|Panels|Transfer Activity"
+    "View|Panels|Drop Stack"
+    "Go|Developer|Jump to Project Root"
+    "Go|Developer|Open in Editor"
+    "Go|Developer|View Git Diffs"
+)
+for spec in "${EXPECT_SUB[@]}"; do
+    IFS="|" read -r menu sub item <<< "$spec"
+    out=$(osa "tell application \"System Events\" to tell ($PROC) to exists menu item \"$item\" of menu 1 of menu item \"$sub\" of menu \"$menu\" of menu bar item \"$menu\" of menu bar 1")
+    [[ "$out" == "true" ]] && pass "$menu → $sub → $item" || fail "$menu → $sub → $item MISSING"
+done
+
 # -- Phase 3: keyboard shortcuts on advertised items -----------------------
 
 echo "=== Phase 3: shortcuts ==="
 # AX reports AXMenuItemCmdChar as the uppercase character regardless of how
 # we set it on the menu item. Compare case-insensitively.
 check_shortcut() {
-    local menu="$1" item="$2" expected_key="$3" expected_mods="$4"
+    local menu="$1" item="$2" expected_key="$3" expected_mods="$4" submenu="${5:-}"
+    # Build the AX element path: items in a submenu need an extra hop through
+    # `menu 1 of menu item "<submenu>"`.
+    local path label
+    if [[ -n "$submenu" ]]; then
+        path="menu item \"$item\" of menu 1 of menu item \"$submenu\" of menu \"$menu\" of menu bar item \"$menu\" of menu bar 1"
+        label="$menu → $submenu → $item"
+    else
+        path="menu item \"$item\" of menu \"$menu\" of menu bar item \"$menu\" of menu bar 1"
+        label="$menu → $item"
+    fi
     local key=$(osa "tell application \"System Events\" to tell ($PROC) to ¬
-        get value of attribute \"AXMenuItemCmdChar\" of menu item \"$item\" of menu \"$menu\" of menu bar item \"$menu\" of menu bar 1")
+        get value of attribute \"AXMenuItemCmdChar\" of $path")
     local mods=$(osa "tell application \"System Events\" to tell ($PROC) to ¬
-        get value of attribute \"AXMenuItemCmdModifiers\" of menu item \"$item\" of menu \"$menu\" of menu bar item \"$menu\" of menu bar 1")
+        get value of attribute \"AXMenuItemCmdModifiers\" of $path")
     # Normalize to uppercase for comparison
     local norm_got=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')
     local norm_exp=$(printf '%s' "$expected_key" | tr '[:lower:]' '[:upper:]')
     if [[ "$norm_got" == "$norm_exp" && "$mods" == "$expected_mods" ]]; then
-        pass "$menu → $item shortcut ⌘$key (mods=$mods)"
+        pass "$label shortcut ⌘$key (mods=$mods)"
     else
-        fail "$menu → $item shortcut got '$key' mods=$mods, expected '$expected_key' mods=$expected_mods"
+        fail "$label shortcut got '$key' mods=$mods, expected '$expected_key' mods=$expected_mods"
     fi
 }
 # AXMenuItemCmdModifiers bitmask:
@@ -166,7 +202,7 @@ check_shortcut "Go" "Home" "h" "1"
 check_shortcut "Rascal" "Settings…" "," "0"
 check_shortcut "File" "New Window" "n" "0"
 check_shortcut "File" "New Smart Folder…" "n" "2"
-check_shortcut "View" "Drop Stack" "d" "4"
+check_shortcut "View" "Drop Stack" "d" "4" "Panels"
 check_shortcut "View" "Show Hidden Files" "." "1"
 check_shortcut "File" "Get Info" "i" "0"
 check_shortcut "Go" "Back" "[" "0"


### PR DESCRIPTION
## What

The menus — the **View** menu especially — had grown overloaded, with several programmer-only commands mixed into the defaults, which is overwhelming for general users. This reorganizes the menu bar for a leaner default **without removing any functionality**. Everything remains reachable from the command palette (`⌘⇧P`), and no keyboard shortcut changed.

## How (what moved where)

- **File ▸ Tools** (new submenu): the six less-frequent utilities now live here — Browse Archive…, Sync Folder…, Analyze Disk Usage…, Find Duplicate Files…, Compare Two Files…, Uninstall App….
- **View ▸ Panes** (new submenu): pane management — Add Pane, Close Pane, Focus Next/Previous Pane, Copy/Move to Other Pane, Synchronized Browsing. The headline **Open Extra Pane** (`⌘\`) stays at the top level.
- **View ▸ Panels** (new submenu): the drawers/overlays — Show Preview, Toggle Terminal, Notes Drawer, Transfer Activity, Drop Stack. (Drop Stack keeps its `⌘⌃D` shortcut, now on the submenu item.)
- **Go ▸ Developer** (new submenu, default): the programmer-oriented commands — Jump to Project Root, Open in Editor, View Git Diffs.
- **Developer mode gating:** added `Settings.developerMode` (off by default) plus a "Show developer commands in menus" checkbox in **Settings ▸ Developer**. When on, the developer commands appear inline in their natural menus (Jump to Project Root in Go; Open in Editor + View Git Diffs in File) and the Developer submenu disappears. The actions are tagged with a new `isDeveloper` flag on `Action` in `Model/Actions.swift`. Toggling the setting rebuilds the menu bar live.

Conservative by design — a leaner default, not a redesign. Nothing was removed; the command palette and the custom-shortcut editor still iterate the full `ActionRegistry.all`, so every command stays reachable and rebindable.

## Headless testing

- **`./build.sh debug`** — clean compile, no new warnings.
- **`./smoketest.sh`** — `549 passed, 0 failed`.
- **`./guitest.sh`** — `118 passed, 0 failed` across all phases. Updated to match the reorg:
  - Phase 2 now expects the new submenu parents (`File ▸ Tools`, `View ▸ Panes`, `View ▸ Panels`, `Go ▸ Developer`) at the top level.
  - New **Phase 2b** audits the relocated items at their nested submenu paths.
  - `check_shortcut` gained an optional submenu argument; the Drop Stack shortcut check (`⌘⌃D`) now targets it inside View ▸ Panels.

> Note: this is a shared CI box with several agents running tests concurrently; their broad `pkill -f .../FinderTwo` occasionally kills a test instance mid-run, producing transient "process not found" noise. Verified green on isolated, uncontended runs and via a direct single-instance Accessibility probe of every menu/submenu/shortcut.

## What to check headed

- Open each top-level menu and confirm the new **Tools / Panes / Panels** submenus look tidy and the items behave.
- In **Settings ▸ Developer**, toggle "Show developer commands in menus" on/off and confirm the developer commands move between the **Go ▸ Developer** submenu and their inline positions (Go / File) live, without needing a relaunch.
- Confirm shortcuts still fire from their new homes: `⌘⌃D` (Drop Stack), `⌘\` (Open Extra Pane), and the developer shortcuts `⌃⌘R` / `⌘⇧O` regardless of the Developer-mode setting.
- Confirm the View-menu checkmarks (Synchronized Browsing, view modes, hidden files) still update correctly now that Sync Browsing lives in the Panes submenu.
