### PR TITLE
fix: preview pane renders blank (build QuickLook against a sized host)

### DIFF
--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -1725,9 +1725,21 @@ final class TestRunner {
         assert("arrangeBy(.kind) sets the sort key", pane.testModel.sort.key == .kind,
                "got=\(pane.testModel.sort.key)")
         pane.arrangeBy(.name)
-        // Preview drawer toggles (builds the QLPreviewView without crashing).
+        // Preview drawer must actually BUILD the QuickLook view, not just flip the
+        // visible flag — regression guard for the blank-pane bug where content was
+        // loaded from the slide's completion handler before the host had a width.
+        pane.testReloadSync()
+        if let previewItem = pane.testCurrentItems.first(where: { !$0.isDirectory }) {
+            pane.testSelectItem(previewItem)
+        }
         pane.togglePreviewDrawer()
+        pane.view.layoutSubtreeIfNeeded()
         assert("preview drawer opens", pane.testPreviewVisible, "not visible")
+        assert("preview host laid out (non-zero)",
+               pane.testPreviewHostSize.width >= 1 && pane.testPreviewHostSize.height >= 1,
+               "host=\(pane.testPreviewHostSize)")
+        assert("preview builds a live QuickLook view",
+               pane.testPreviewHasQLView, "no QLPreviewView built")
         pane.togglePreviewDrawer()
         assert("preview drawer closes", !pane.testPreviewVisible, "still visible")
 

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -174,14 +174,18 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     func togglePreviewDrawer() {
         previewVisible.toggle()
         if previewVisible {
-            // Load the preview only once the drawer has slid to full width —
-            // QuickLook needs a non-zero frame (PreviewDrawerView guards this,
-            // but loading at full size avoids a blank first paint).
-            animateDrawer(previewView, previewWidthConstraint, open: true, size: 260,
-                          afterOpen: { [weak self] in
-                              guard let self, self.previewVisible else { return }
-                              self.updatePreviewContent()
-                          })
+            // Open to full width and lay out *before* loading, so QuickLook always
+            // builds against a real, non-zero host frame. Loading from the slide's
+            // completion handler was unreliable: AppKit fires that handler
+            // synchronously — before the width constraint is committed — whenever the
+            // change isn't animatable (e.g. the window isn't key), so the host read
+            // 0pt-wide, PreviewDrawerView's size guard dropped the QLPreviewView, and
+            // the pane stayed permanently blank. Snapping open (vs. the other drawers'
+            // slide) is the deliberate trade for a preview that always renders.
+            previewView.isHidden = false
+            previewWidthConstraint.constant = 260
+            view.layoutSubtreeIfNeeded()
+            updatePreviewContent()
         } else {
             animateDrawer(previewView, previewWidthConstraint, open: false, size: 260)
         }
@@ -1132,6 +1136,8 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     var testTabStripVisible: Bool { !tabStrip.isHidden }
     var testTabStrip: TabStripView { tabStrip }
     var testPreviewVisible: Bool { previewVisible }
+    var testPreviewHostSize: NSSize { previewView.testQLHostSize }
+    var testPreviewHasQLView: Bool { previewView.testHasLiveQLView }
     var testHotbarHeight: CGFloat { hotbarHeightConstraint.constant }
     var testToolbarTopInset: CGFloat { topInsetConstraint.constant }
     func testToolbarHasFocusAPI() -> Bool {

--- a/Sources/FinderTwo/UI/PreviewDrawerView.swift
+++ b/Sources/FinderTwo/UI/PreviewDrawerView.swift
@@ -102,6 +102,14 @@ final class PreviewDrawerView: NSView, ThemeObserving {
             infoLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
             infoLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
         ])
+        // Guarantee the QuickLook host keeps a real height even when the pane is
+        // short (e.g. the bottom terminal drawer is open) — otherwise the label
+        // chain can squeeze qlHost to zero and reloadPreview()'s size guard drops
+        // the view. High (not required) priority so it yields if the window is
+        // genuinely too small.
+        let qlHostMinHeight = qlHost.heightAnchor.constraint(greaterThanOrEqualToConstant: 80)
+        qlHostMinHeight.priority = .defaultHigh
+        qlHostMinHeight.isActive = true
         subscribeToTheme(self)
     }
     required init?(coder: NSCoder) { fatalError() }
@@ -112,4 +120,8 @@ final class PreviewDrawerView: NSView, ThemeObserving {
         nameLabel.textColor = t.id == "system" ? .labelColor : t.labelPrimary
         infoLabel.textColor = t.id == "system" ? .secondaryLabelColor : t.labelSecondary
     }
+
+    // MARK: - Test hooks
+    var testQLHostSize: NSSize { qlHost.bounds.size }
+    var testHasLiveQLView: Bool { ql != nil }
 }


### PR DESCRIPTION
## What

Fixes the **blank preview pane** multiple users reported after the v0.1.4 launch ("the preview pane doesn't work for me, at all").

## Root cause

`PaneController.togglePreviewDrawer()` loaded the preview's content from the slide animation's **completion handler** (`afterOpen`). `NSAnimationContext.runAnimationGroup(_:completionHandler:)` runs that handler **synchronously — before the width constraint is committed** — whenever the change isn't animatable (e.g. the window isn't key). At that point `qlHost.bounds.width == 0`, so `PreviewDrawerView.reloadPreview()`'s `guard width >= 1` bailed and the `QLPreviewView` was **never built**, with no retry → permanently blank.

The tell: the other three drawers (terminal, git-diff, notes) load content in the *synchronous* `onOpen`; only preview used `afterOpen`. Regression from `69ada9f` ("slide drawers open/closed"), which shipped in v0.1.4.

Note there is **no preview _toolbar button_** — the controls are **View ▸ Show Preview** and **⌥⌘P**. (Adding a toolbar/hotbar button is a possible follow-up, since users look for one.)

## Fix

- `togglePreviewDrawer()` now sets the drawer to full width and lays out **synchronously before loading**, so QuickLook always builds against a real, non-zero host. The preview now *snaps* open (the other drawers still slide) — a deliberate trade for "always renders."
- Adds a `defaultHigh` **min-height** on the QuickLook host so a short window (e.g. terminal drawer open) can't squeeze it to zero and re-trip the guard.

## Test

Upgraded the existing preview test **in place** (no new `T`-label — avoids the cross-PR `TestRunner.swift` conflict): it now selects a file, toggles the pane, and asserts the host is laid out **and a live `QLPreviewView` is built** — which fails on the old code and passes here.

```
=== 551 passed, 0 failed ===
✓ preview drawer opens
✓ preview host laid out (non-zero)
✓ preview builds a live QuickLook view
✓ preview drawer closes
```

Verified headless via `./build.sh debug` + `./smoketest.sh` — no window popped.
