### PR TITLE
fix: keep files that can't be stat'd instead of hiding them

### DIFF
--- a/Sources/FinderTwo/FS/FastDirScan.swift
+++ b/Sources/FinderTwo/FS/FastDirScan.swift
@@ -39,30 +39,47 @@ enum FastDirScan {
         defer { closedir(d) }
 
         let parentPath = path.hasSuffix("/") ? path : path + "/"
+        // Raw bytes of the parent path (no trailing NUL), so each child's lstat path
+        // can be assembled from bytes rather than a lossy String round-trip.
+        let parentBytes: [CChar] = parentPath.withCString { p in
+            Array(UnsafeBufferPointer(start: p, count: strlen(p)))
+        }
         while let entryPtr = readdir(d) {
             let entry = entryPtr.pointee
-            // Skip "." and ".."
-            var name = withUnsafeBytes(of: entry.d_name) { rawPtr -> String in
-                let buf = rawPtr.bindMemory(to: CChar.self)
-                return String(cString: buf.baseAddress!)
-            }
-            if name == "." || name == ".." { continue }
 
-            // Build path C-string for lstat
-            let fullPath = parentPath + name
+            // Assemble "<parent><name>" as a NUL-terminated C path straight from the
+            // raw d_name bytes. Do NOT decode the name to a String and rebuild the
+            // path from it: String(cString:) substitutes U+FFFD for any byte that
+            // isn't valid UTF-8, so the path would point at a file that doesn't exist,
+            // lstat would fail, and the entry would silently vanish from the listing
+            // (names copied from Linux, legacy encodings, some network volumes) — the
+            // "some folders don't show all the files" bug.
+            var pathBytes = parentBytes
+            var isDotEntry = false
+            let displayName: String = withUnsafeBytes(of: entry.d_name) { rawPtr -> String in
+                let base = rawPtr.bindMemory(to: CChar.self).baseAddress!
+                let len = strlen(base)
+                if (len == 1 && base[0] == 0x2E) ||
+                   (len == 2 && base[0] == 0x2E && base[1] == 0x2E) {
+                    isDotEntry = true
+                    return ""
+                }
+                pathBytes.append(contentsOf: UnsafeBufferPointer(start: base, count: len))
+                return String(cString: base)   // display only; may contain U+FFFD
+            }
+            if isDotEntry { continue }          // "." / ".."
+            pathBytes.append(0)                 // NUL-terminate for the C calls
+
             var st = stat()
-            if lstat(fullPath, &st) != 0 { continue }
+            if lstat(pathBytes, &st) != 0 { continue }
 
             let isSymlink = (st.st_mode & S_IFMT) == S_IFLNK
             let isDir: Bool
             if isSymlink {
                 // Resolve symlinks once so directory icons follow Finder behavior.
                 var stTarget = stat()
-                if stat(fullPath, &stTarget) == 0 {
-                    isDir = (stTarget.st_mode & S_IFMT) == S_IFDIR
-                } else {
-                    isDir = false
-                }
+                isDir = (stat(pathBytes, &stTarget) == 0)
+                    && (stTarget.st_mode & S_IFMT) == S_IFDIR
             } else {
                 isDir = (st.st_mode & S_IFMT) == S_IFDIR
             }
@@ -76,18 +93,21 @@ enum FastDirScan {
             // is what `du` and Disk Utility's "used" are based on. For symlinks
             // this is the link's own (tiny) allocation, not the target's.
             let physicalSize = Int64(st.st_blocks) * 512
+            // Display name keeps its original encoding, precomposed for HFS+/APFS
+            // consistency (cheap for ASCII names).
+            let name = (displayName as NSString).precomposedStringWithCanonicalMapping
             let isHidden = name.hasPrefix(".")
             let dot = name.lastIndex(of: ".")
             let ext = (dot != nil && dot != name.startIndex)
                 ? String(name[name.index(after: dot!)...]).lowercased()
                 : ""
 
-            // Strip a take-it-while strategy: name keeps its original encoding
-            // even when filesystem returns precomposed unicode (HFS+/APFS varies).
-            // Compatibility-decompose only when needed (very cheap for ASCII names).
-            name = (name as NSString).precomposedStringWithCanonicalMapping
-
-            let url = URL(fileURLWithPath: fullPath, isDirectory: isDir)
+            // Build the URL from the file-system representation (the real bytes) so it
+            // round-trips to the actual file even when the name isn't valid UTF-8.
+            let url = pathBytes.withUnsafeBufferPointer { bp in
+                URL(fileURLWithFileSystemRepresentation: bp.baseAddress!,
+                    isDirectory: isDir, relativeTo: nil)
+            }
             out.append(Entry(
                 url: url, name: name,
                 isDirectory: isDir, isSymlink: isSymlink, isHidden: isHidden,

--- a/Sources/FinderTwo/FS/FastDirScan.swift
+++ b/Sources/FinderTwo/FS/FastDirScan.swift
@@ -70,29 +70,46 @@ enum FastDirScan {
             if isDotEntry { continue }          // "." / ".."
             pathBytes.append(0)                 // NUL-terminate for the C calls
 
+            // Fetch metadata — but do NOT drop the entry if lstat fails. readdir
+            // already reported the file exists; a failed lstat (a directory that's
+            // readable but not searchable — mode r-- with no x — or an item racing
+            // deletion) used to `continue` and silently hide the file, which is the
+            // real local "some folders don't show all the files" bug. Keep the row
+            // and fall back to readdir's d_type for the icon.
             var st = stat()
-            if lstat(pathBytes, &st) != 0 { continue }
+            let haveStat = lstat(pathBytes, &st) == 0
 
-            let isSymlink = (st.st_mode & S_IFMT) == S_IFLNK
+            let isSymlink: Bool
             let isDir: Bool
-            if isSymlink {
-                // Resolve symlinks once so directory icons follow Finder behavior.
-                var stTarget = stat()
-                isDir = (stat(pathBytes, &stTarget) == 0)
-                    && (stTarget.st_mode & S_IFMT) == S_IFDIR
+            if haveStat {
+                isSymlink = (st.st_mode & S_IFMT) == S_IFLNK
+                if isSymlink {
+                    // Resolve symlinks once so directory icons follow Finder behavior.
+                    var stTarget = stat()
+                    isDir = (stat(pathBytes, &stTarget) == 0)
+                        && (stTarget.st_mode & S_IFMT) == S_IFDIR
+                } else {
+                    isDir = (st.st_mode & S_IFMT) == S_IFDIR
+                }
             } else {
-                isDir = (st.st_mode & S_IFMT) == S_IFDIR
+                // No stat available — use the directory entry's own type, which
+                // readdir provides without a stat. DT_UNKNOWN falls through to file.
+                isSymlink = Int32(entry.d_type) == DT_LNK
+                isDir = Int32(entry.d_type) == DT_DIR
             }
-            let mtime = Date(timeIntervalSince1970: Double(st.st_mtimespec.tv_sec)
-                                + Double(st.st_mtimespec.tv_nsec) / 1_000_000_000)
-            let ctime = Date(timeIntervalSince1970: Double(st.st_birthtimespec.tv_sec)
-                                + Double(st.st_birthtimespec.tv_nsec) / 1_000_000_000)
-            let size = isDir ? Int64(-1) : Int64(st.st_size)
-            // st_blocks is in fixed 512-byte units (POSIX), independent of the
-            // filesystem block size — this is the actual on-disk footprint and
-            // is what `du` and Disk Utility's "used" are based on. For symlinks
-            // this is the link's own (tiny) allocation, not the target's.
-            let physicalSize = Int64(st.st_blocks) * 512
+            let mtime = haveStat
+                ? Date(timeIntervalSince1970: Double(st.st_mtimespec.tv_sec)
+                        + Double(st.st_mtimespec.tv_nsec) / 1_000_000_000)
+                : Date(timeIntervalSince1970: 0)
+            let ctime = haveStat
+                ? Date(timeIntervalSince1970: Double(st.st_birthtimespec.tv_sec)
+                        + Double(st.st_birthtimespec.tv_nsec) / 1_000_000_000)
+                : Date(timeIntervalSince1970: 0)
+            let size = isDir ? Int64(-1) : (haveStat ? Int64(st.st_size) : 0)
+            // st_blocks is in fixed 512-byte units (POSIX) — the actual on-disk
+            // footprint (what `du` / Disk Utility "used" report). For symlinks this
+            // is the link's own (tiny) allocation, not the target's.
+            let physicalSize = haveStat ? Int64(st.st_blocks) * 512 : 0
             // Display name keeps its original encoding, precomposed for HFS+/APFS
             // consistency (cheap for ASCII names).
             let name = (displayName as NSString).precomposedStringWithCanonicalMapping
@@ -112,8 +129,10 @@ enum FastDirScan {
                 url: url, name: name,
                 isDirectory: isDir, isSymlink: isSymlink, isHidden: isHidden,
                 size: size, modified: mtime, created: ctime, ext: ext,
-                physicalSize: physicalSize, inode: UInt64(st.st_ino),
-                device: Int32(st.st_dev), linkCount: Int(st.st_nlink)
+                physicalSize: physicalSize,
+                inode: haveStat ? UInt64(st.st_ino) : 0,
+                device: haveStat ? Int32(st.st_dev) : 0,
+                linkCount: haveStat ? Int(st.st_nlink) : 1
             ))
         }
         return out

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -1746,6 +1746,31 @@ final class TestRunner {
         pane.toggleHidden()
         pane.testReloadSync()
 
+        // --- T48b: fast scan must list files with non-UTF-8 names ---
+        // Regression guard: the readdir fast path used to rebuild the lstat path from
+        // a lossy String(cString:) decode, so a file whose name isn't valid UTF-8 got
+        // a mangled path, lstat failed, and the entry silently vanished ("some folders
+        // don't show all the files").
+        let utf8Dir = sandbox.appendingPathComponent("utf8drop")
+        try? FileManager.default.createDirectory(at: utf8Dir, withIntermediateDirectories: true)
+        for n in ["a.txt", "b.txt", "c.txt"] {
+            try? "x".write(to: utf8Dir.appendingPathComponent(n), atomically: true, encoding: .utf8)
+        }
+        // "bad\u{FF}.txt": a stray 0xFF byte is not valid UTF-8 and can't be written
+        // through a Swift String path, so assemble the path from raw bytes.
+        var badNamePath = Array(utf8Dir.path.utf8CString.dropLast())   // drop trailing NUL
+        badNamePath.append(contentsOf: "/bad".utf8.map { CChar(bitPattern: $0) })
+        badNamePath.append(CChar(bitPattern: 0xFF))
+        badNamePath.append(contentsOf: ".txt".utf8.map { CChar(bitPattern: $0) })
+        badNamePath.append(0)
+        let badURL = badNamePath.withUnsafeBufferPointer {
+            URL(fileURLWithFileSystemRepresentation: $0.baseAddress!, isDirectory: false, relativeTo: nil)
+        }
+        try? Data("x".utf8).write(to: badURL)
+        let utf8Scan = FastDirScan.list(utf8Dir)
+        assert("fast scan lists files with non-UTF-8 names",
+               utf8Scan.count == 4, "expected 4, got \(utf8Scan.count): \(utf8Scan.map { $0.name })")
+
         // --- T49: PathBar emits ordered segments root → leaf ---
         let probeURL = URL(fileURLWithPath: "/Users/chang/Desktop")
         let segs = PathBarView.testSegments(for: probeURL)

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -1746,30 +1746,24 @@ final class TestRunner {
         pane.toggleHidden()
         pane.testReloadSync()
 
-        // --- T48b: fast scan must list files with non-UTF-8 names ---
-        // Regression guard: the readdir fast path used to rebuild the lstat path from
-        // a lossy String(cString:) decode, so a file whose name isn't valid UTF-8 got
-        // a mangled path, lstat failed, and the entry silently vanished ("some folders
-        // don't show all the files").
-        let utf8Dir = sandbox.appendingPathComponent("utf8drop")
-        try? FileManager.default.createDirectory(at: utf8Dir, withIntermediateDirectories: true)
-        for n in ["a.txt", "b.txt", "c.txt"] {
-            try? "x".write(to: utf8Dir.appendingPathComponent(n), atomically: true, encoding: .utf8)
+        // --- T48b: fast scan keeps entries even when lstat fails ---
+        // The real, locally-reproducible "some folders don't show all the files" bug:
+        // a directory that's readable but NOT searchable (mode r--, no execute) lets
+        // readdir list the names, but makes lstat on every entry fail (EACCES). The old
+        // fast path `continue`d on lstat failure and hid every file. (The earlier
+        // non-UTF-8-name variant can't be reproduced on APFS/HFS+, which enforce valid
+        // Unicode filenames — macOS rewrites bad bytes to U+FFFD, so no such file can
+        // exist locally to test against.)
+        let noExecDir = sandbox.appendingPathComponent("noexec")
+        try? FileManager.default.createDirectory(at: noExecDir, withIntermediateDirectories: true)
+        for n in ["p.txt", "q.txt", "r.txt"] {
+            try? "x".write(to: noExecDir.appendingPathComponent(n), atomically: true, encoding: .utf8)
         }
-        // "bad\u{FF}.txt": a stray 0xFF byte is not valid UTF-8 and can't be written
-        // through a Swift String path, so assemble the path from raw bytes.
-        var badNamePath = Array(utf8Dir.path.utf8CString.dropLast())   // drop trailing NUL
-        badNamePath.append(contentsOf: "/bad".utf8.map { CChar(bitPattern: $0) })
-        badNamePath.append(CChar(bitPattern: 0xFF))
-        badNamePath.append(contentsOf: ".txt".utf8.map { CChar(bitPattern: $0) })
-        badNamePath.append(0)
-        let badURL = badNamePath.withUnsafeBufferPointer {
-            URL(fileURLWithFileSystemRepresentation: $0.baseAddress!, isDirectory: false, relativeTo: nil)
-        }
-        try? Data("x".utf8).write(to: badURL)
-        let utf8Scan = FastDirScan.list(utf8Dir)
-        assert("fast scan lists files with non-UTF-8 names",
-               utf8Scan.count == 4, "expected 4, got \(utf8Scan.count): \(utf8Scan.map { $0.name })")
+        try? FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: noExecDir.path)
+        let noExecScan = FastDirScan.list(noExecDir)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: noExecDir.path)  // restore so cleanup can delete
+        assert("fast scan keeps entries when lstat fails (readable-but-not-searchable dir)",
+               noExecScan.count == 3, "expected 3, got \(noExecScan.count): \(noExecScan.map { $0.name })")
 
         // --- T49: PathBar emits ordered segments root → leaf ---
         let probeURL = URL(fileURLWithPath: "/Users/chang/Desktop")

--- a/Sources/FinderTwo/UI/GalleryViewController.swift
+++ b/Sources/FinderTwo/UI/GalleryViewController.swift
@@ -15,6 +15,9 @@ final class GalleryViewController: NSViewController, ThemeObserving {
     private var items: [FileItem] = []
     private(set) var focused: FileItem?
     private var stripButtons: [NSButton] = []
+    /// How many items the cap dropped from the current folder — drives the
+    /// "+N more" indicator so a large folder doesn't look like it's hiding files.
+    private var truncatedCount = 0
 
     override func loadView() {
         let root = NSView()
@@ -71,6 +74,7 @@ final class GalleryViewController: NSViewController, ThemeObserving {
     private static let maxStripItems = 400
 
     func reload(_ items: [FileItem]) {
+        truncatedCount = max(0, items.count - Self.maxStripItems)
         self.items = items.count > Self.maxStripItems ? Array(items.prefix(Self.maxStripItems)) : items
         rebuildStrip()
         focus(self.items.first)
@@ -97,6 +101,19 @@ final class GalleryViewController: NSViewController, ThemeObserving {
             b.addGestureRecognizer(dbl)
             strip.addArrangedSubview(b)
             stripButtons.append(b)
+        }
+        // The strip is capped for performance (see maxStripItems). Surface the
+        // remainder so a big folder doesn't look like it's silently dropping files —
+        // the full set is always in List/Column view and the status-bar count.
+        if truncatedCount > 0 {
+            let more = NSTextField(labelWithString: "+\(truncatedCount) more")
+            more.font = .systemFont(ofSize: 11)
+            more.textColor = .secondaryLabelColor
+            more.alignment = .center
+            more.translatesAutoresizingMaskIntoConstraints = false
+            more.widthAnchor.constraint(greaterThanOrEqualToConstant: 72).isActive = true
+            more.toolTip = "Gallery shows the first \(Self.maxStripItems) items for performance. Switch to List or Column view to see all \(items.count + truncatedCount)."
+            strip.addArrangedSubview(more)
         }
     }
 


### PR DESCRIPTION
## What
Fixes the real, locally-reproducible cause of **"some folders don't show all the files."**

## Root cause
`FastDirScan` (the `readdir` fast path) **dropped any entry whose `lstat` failed** (`if lstat(...) != 0 { continue }`). But `readdir` had already reported the file exists — so a folder that's **readable but not searchable** (mode `r--`, no execute bit) or a file **racing deletion** had its entries silently vanish. On such a folder `readdir` lists the names, but `lstat` on each returns `EACCES`/`ENOENT`, so the old code hid *every* file.

> This PR originally targeted **non-UTF-8 filenames** — but that can't happen on a local APFS/HFS+ volume: macOS enforces valid Unicode filenames and rewrites bad bytes to `U+FFFD` (verified: even a raw byte-write comes back as `bad\u{FFFD}.txt`). That variant only affects network/foreign volumes; the byte-accurate path handling for it is retained, but it is not the local bug.

## Fix
- **Keep the entry when `lstat` fails**; fall back to `readdir`'s `d_type` for the icon, leave metadata blank when it can't be read.
- Retain byte-accurate path/URL (file-system representation) for genuinely non-UTF-8 names on network volumes.
- **Gallery** view's 400-item filmstrip cap now shows a **"+N more"** indicator (with a tooltip) instead of silently truncating — a big folder in Gallery view no longer looks like it's dropping files.

## Test
Replaces the earlier **false-positive** test (which couldn't create a non-UTF-8 file on APFS) with a **readable-but-not-searchable-dir** test that genuinely exercises the drop — it fails on the old code, passes here:

```
=== 550 passed, 0 failed ===
✓ fast scan keeps entries when lstat fails (readable-but-not-searchable dir)
```

Manually verified: a `chmod 0444` folder with 3 files now shows all 3 (blank size/date) instead of empty. Headless `build.sh` + `smoketest.sh` — no window popped.
