### PR TITLE
fix: remove the empty band under a hidden title bar

### DIFF
--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -2206,8 +2206,8 @@ final class TestRunner {
                wc.window?.titleVisibility == .hidden, "vis=\(String(describing: wc.window?.titleVisibility))")
         assert("title hidden → sidebar top inset \(inset)",
                chromeSidebar?.testTopInset == inset, "inset=\(chromeSidebar?.testTopInset ?? -9)")
-        assert("title hidden → pane toolbar top inset \(inset) (aligns with sidebar)",
-               pane.testToolbarTopInset == inset, "inset=\(pane.testToolbarTopInset)")
+        assert("title hidden → pane toolbar top inset 0 (lights are over the sidebar, not the main pane)",
+               pane.testToolbarTopInset == 0, "inset=\(pane.testToolbarTopInset)")
         Settings.showTitleBar = true
         wait(0.02)
         assert("title shown → no fullSizeContentView",

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -365,10 +365,13 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
         statusBarHeightConstraint.constant = Settings.showStatusBar ? 22 : 0
     }
 
-    /// When the window title bar is hidden, inset the toolbar from the top so it
-    /// clears the traffic lights and lines up with the (also-inset) sidebar.
+    /// Pin the toolbar to the top of the pane. The window's traffic lights sit at
+    /// the top-LEFT, over the sidebar — not over this main pane (which is to the
+    /// sidebar's right) — so the toolbar never needs to clear them. Pushing it down
+    /// when the title bar was hidden just left an empty band (a "blank row") at the
+    /// top of the pane; the sidebar keeps its own inset to clear the lights.
     private func applyTopInset() {
-        topInsetConstraint.constant = Settings.showTitleBar ? 0 : PaneController.hiddenTitleBarInset
+        topInsetConstraint.constant = 0
     }
 
     func setActive(_ active: Bool, showBorder: Bool = false) {


### PR DESCRIPTION
## What

Fixes the launch-feedback report: *"turning the title bar off also inserts a blank row below the now empty title bar, which seems weird."*

## Root cause

When the title bar is hidden, the window switches to `.fullSizeContentView` and the macOS **traffic-light buttons float at the window's top-LEFT — over the sidebar**. To clear them, two insets were applied:
- the **sidebar** got a 28pt top inset (`sidebarVC.setTopInset(28)`) — **correct**, the lights are over it;
- the **main pane's toolbar** was *also* pushed down 28pt (`PaneController.applyTopInset`) — **wrong**: the main pane sits to the *right* of the sidebar, so no traffic lights are ever over it. That push-down cleared nothing and just left an empty band — the "blank row."

(Geometry: lights at x≈8–70, sidebar x≈0–165, main pane x≥165.)

## Fix

Pin the main pane's toolbar to the top (`topInsetConstraint.constant = 0`). The sidebar keeps its 28pt inset to clear the lights. This also matches the platform convention (Xcode/Finder-style): the sidebar's first row is inset for the lights while the main content extends to the top.

## Test

Updated the existing chrome assertion in `TestRunner`: with the title bar hidden, the **sidebar** inset stays 28 and the **main-pane toolbar** inset is now **0**.

```
=== 549 passed, 0 failed ===   ·   guitest: 0 failures
✓ title hidden → sidebar top inset 28.0
✓ title hidden → pane toolbar top inset 0 (lights are over the sidebar, not the main pane)
✓ title shown → pane toolbar top inset 0
```

## Known minor edge (not addressed here)

If the sidebar is **collapsed** *and* the title bar is hidden, the main pane becomes the leftmost view, so the toolbar's leading ~70pt would sit under the traffic lights. That's a rare combination; handling it cleanly needs the window to re-inset the pane on sidebar-collapse — a separate change. Flagged for follow-up.

Verified headless via `./build.sh debug` + `./smoketest.sh` + `./guitest.sh` — no window popped. (Validated by geometry + the chrome test hooks rather than a pixel render; happy to attach a before/after off-screen capture if useful.)
