### PR TITLE
Fix list drag completion

### DIFF
--- a/Sources/FinderTwo/UI/FileListController.swift
+++ b/Sources/FinderTwo/UI/FileListController.swift
@@ -1552,7 +1552,7 @@ final class FileListTableView: NSTableView {
     }
     override func draggingEnded(_ sender: NSDraggingInfo) {
         listController?.cancelSpring()
-        super.draggingEnded(sender)
+        // This optional destination callback has no NSTableView implementation to forward to.
     }
 
     /// Build the context menu fresh per right-click. On a row: select it first


### PR DESCRIPTION
## What changed

- Stop forwarding `draggingEnded(_:)` to `NSTableView`.
- Keep Rascal's spring-loaded-folder timer cleanup.
- Document why the optional destination callback must not call `super`.

## Root cause

Ending a list-row drag raised:

```text
-[FinderTwo.FileListTableView draggingEnded:]: unrecognized selector sent to instance
```

The exception occurred inside AppKit's drag-completion path. It left the drag tracking session stuck, which suppressed macOS multi-touch gestures until Rascal quit.

## User impact

List-row drags can now complete without dispatching an unavailable superclass selector. This should prevent folder text from remaining in drag feedback state and restore normal trackpad gestures after a drop.

## Validation

- Swift debug build completed.
- `./guitest.sh`: 0 failures on warm run.
- `./smoketest.sh`: 604 passed, 1 environment-specific pre-existing failure because the test expects a volume named `Macintosh HD` while the test machine's volume is named `macOS`.
- Exact three-finger-drag reproduction will be verified with the locally installed patched build.
