### PR TITLE
Fix Vim filter acceptance and search field controls

### DIFF
--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -2038,7 +2038,7 @@ final class TestRunner {
         }
         VimMode.shared.setEnabled(false)
 
-        // --- T56c: vim '/' and '?' focuses filter, Esc cancels and focuses file list ---
+        // --- T56c: vim '/' and '?' focus filter; Return accepts and Esc cancels ---
         VimMode.shared.setEnabled(true)
         pane.navigate(to: sandbox)
         pane.testReloadSync()
@@ -2061,9 +2061,18 @@ final class TestRunner {
                                              isARepeat: false, keyCode: 44)!
         let questionHandled = VimMode.shared.handle(event: questionEvent, in: pane, fileList: pane.testFileList)
         assert("vim '?' is consumed", questionHandled, "not handled")
+
+        // Return accepts the current filter, preserving it and returning focus to the list.
+        pane.testFocusSearchField(insert: "subdir")
+        let returnHandled = pane.testAcceptSearch()
+        assert("Toolbar insertNewline is handled", returnHandled, "not handled")
+        assert("Search text preserved on Return", pane.testModel.filterText == "subdir",
+               "filter changed: \(pane.testModel.filterText)")
+        assert("File list focused on Return", pane.view.window?.firstResponder === pane.testFileList.tableView,
+               "file list not focused")
         
         // Check that Esc cancels search and returns focus to the file list
-        pane.testFocusSearchField(insert: "subdir")
+        pane.testFocusSearchField()
         let escHandled = pane.testCancelSearch()
         assert("Toolbar cancelOperation is handled", escHandled, "not handled")
         assert("Search text cleared on Esc", pane.testModel.filterText.isEmpty, "filter not cleared: \(pane.testModel.filterText)")

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -324,6 +324,7 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
         toolbar.onUp = { [weak self] in self?.goUp() }
         toolbar.onCommit = { [weak self] text in self?.commitTypedPath(text) }
         toolbar.onSearchChanged = { [weak self] q in self?.applyFilter(q) }
+        toolbar.onSearchAccepted = { [weak self] in self?.focusFileList() }
         toolbar.onSearchCancelled = { [weak self] in self?.focusFileList() }
 
         pathBar.onSelectSegment = { [weak self] url in self?.navigate(to: url) }
@@ -1153,6 +1154,9 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     }
     func testCancelSearch() -> Bool {
         return toolbar.testSimulateCancelSearch()
+    }
+    func testAcceptSearch() -> Bool {
+        return toolbar.testSimulateAcceptSearch()
     }
 }
 

--- a/Sources/FinderTwo/UI/ToolbarView.swift
+++ b/Sources/FinderTwo/UI/ToolbarView.swift
@@ -171,12 +171,15 @@ final class ToolbarView: NSView, NSTextFieldDelegate, NSSearchFieldDelegate, The
             pathField.layer?.backgroundColor = bgColor.cgColor
             pathField.layer?.cornerRadius = 5
             
-            searchField.isBezeled = false
-            searchField.isBordered = false
-            searchField.drawsBackground = false
-            searchField.wantsLayer = true
-            searchField.layer?.backgroundColor = bgColor.cgColor
-            searchField.layer?.cornerRadius = 5
+            // Keep NSSearchField's native bezel machinery: its cell uses the
+            // bezel geometry to position and hit-test the search/cancel buttons.
+            // Turning it off makes typed text overlap the magnifier and leaves
+            // the visible cancel button with a broken hit region.
+            searchField.wantsLayer = false
+            searchField.isBezeled = true
+            searchField.isBordered = true
+            searchField.drawsBackground = true
+            searchField.backgroundColor = bgColor
         } else {
             pathField.wantsLayer = false
             pathField.isBezeled = true

--- a/Sources/FinderTwo/UI/ToolbarView.swift
+++ b/Sources/FinderTwo/UI/ToolbarView.swift
@@ -7,6 +7,7 @@ final class ToolbarView: NSView, NSTextFieldDelegate, NSSearchFieldDelegate, The
     var onUp: (() -> Void)?
     var onCommit: ((String) -> Void)?
     var onSearchChanged: ((String) -> Void)?
+    var onSearchAccepted: (() -> Void)?
     var onSearchCancelled: (() -> Void)?
 
     var canGoBack: Bool = false {
@@ -190,11 +191,16 @@ final class ToolbarView: NSView, NSTextFieldDelegate, NSSearchFieldDelegate, The
         }
     }
 
-    // NSTextFieldDelegate (path commit + ESC on search field)
+    // NSTextFieldDelegate (path commit + accept/cancel on search field)
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         if control === pathField, commandSelector == #selector(NSResponder.insertNewline(_:)) {
             onCommit?(pathField.stringValue)
             window?.makeFirstResponder(nil)
+            return true
+        }
+        if control === searchField, commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            window?.makeFirstResponder(nil)
+            onSearchAccepted?()
             return true
         }
         if control === searchField, commandSelector == #selector(NSResponder.cancelOperation(_:)) {
@@ -218,5 +224,11 @@ final class ToolbarView: NSView, NSTextFieldDelegate, NSSearchFieldDelegate, The
     func testSimulateCancelSearch() -> Bool {
         return control(searchField, textView: NSTextView(),
                        doCommandBy: #selector(NSResponder.cancelOperation(_:)))
+    }
+
+    /// Test hook: simulate Return on the search field using its real identity.
+    func testSimulateAcceptSearch() -> Bool {
+        return control(searchField, textView: NSTextView(),
+                       doCommandBy: #selector(NSResponder.insertNewline(_:)))
     }
 }


### PR DESCRIPTION
## Summary

Vim mode:

- Pressing ⏎ after filtering now accepts the filter and returns focus to the file list, so `j`/`k` navigation works.
- Escape still clears the filter.

Addtionally:

- Fixed the search text overlapping the magnifier.
- Fixed the✖️ button so it clears the search again.

## Testing

- Added regression coverage for accepting a filter with ⏎
- `./build.sh debug` -> passed
  - Verified that ⏎ preserves the filter and focuses the file list
  - Verified that **ESC** clears the filter and focuses the file list
- `./smoketest.sh` -> passed
- `./guitest.sh` -> passed

## Demo

In the demo, Vim mode is activated and following actions have been executed

1. Start search with `/` -> type in query `git` -> hit ⏎ to confirm search -> use `j` to select item
2. Use ✖️ button to clear input. One can also observe the placement of  🔍 icon.

### Before

1. Executed on live app (`rascal 0.1.5`)
2. Filter retains focus, no way to select filter matches (e.g. with ⏎ and `j`)
3. 🔍 overlaps with text, ✖️ does not clear input

https://github.com/user-attachments/assets/1c22ecd5-9fe0-4ca0-b1cb-937e5c2af6b7

### After

1. Executed on local app, built with `./build.sh debug`
2. Fixed. Use ⏎ to accept filter and use e.g. `j` to select items
3. Fixed. 🔍 no longer overlaps and ✖️ clears input

https://github.com/user-attachments/assets/548ee8b2-cb9e-44dc-aaa5-02b20ce855a1 