### PR TITLE
Off-screen UI snapshots for headless visual verification

### DIFF
--- a/Sources/FinderTwo/AppDelegate.swift
+++ b/Sources/FinderTwo/AppDelegate.swift
@@ -56,6 +56,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             }
             return
         }
+        // Headless UI snapshot: FT_HEADLESS_TESTING=1 FT_SNAPSHOT=<outdir>
+        // [FT_SNAPSHOT_PATH=<folder>] [FT_SNAPSHOT_THEMES=a,b]. See Snapshot.swift.
+        if let snapDir = ProcessInfo.processInfo.environment["FT_SNAPSHOT"] {
+            DispatchQueue.main.async { Snapshot.runStandalone(outDir: snapDir, appDelegate: self) }
+            return
+        }
         // Headless disk-usage probe — prints the scanner's total for a path so it
         // can be diffed against `du -sh`. FT_DU=<dir>.
         if let duPath = ProcessInfo.processInfo.environment["FT_DU"] {

--- a/Sources/FinderTwo/Tests/Snapshot.swift
+++ b/Sources/FinderTwo/Tests/Snapshot.swift
@@ -1,0 +1,119 @@
+import AppKit
+
+/// Off-screen visual capture for headless verification.
+///
+/// Headless runs (`FT_HEADLESS_TESTING=1`) park windows thousands of points off
+/// every display, but AppKit still lays them out and the WindowServer still
+/// composites them — so we can grab a pixel-exact PNG of any of our own windows
+/// with `CGWindowListCreateImage` without anything ever appearing on screen and
+/// without Screen-Recording permission.
+///
+/// Two entry points:
+///
+///   • `FT_SNAPSHOT_DIR=<dir>` — while `smoketest.sh` runs, the TestRunner
+///     calls `Snapshot.take(win, "name")` at interesting states and PNGs land
+///     in <dir>. Unset ⇒ no-op, so the normal test run is unaffected.
+///
+///   • `FT_SNAPSHOT=<dir> [FT_SNAPSHOT_PATH=<folder>] [FT_SNAPSHOT_THEMES=a,b]`
+///     — standalone: open a real browser window at <folder> (default: cwd),
+///     capture it under each theme, capture the Settings window, exit. This is
+///     what `./snapshot.sh` drives. Use it to eyeball any UI change without a
+///     second monitor.
+@MainActor
+enum Snapshot {
+    static var dir: URL? {
+        guard let p = ProcessInfo.processInfo.environment["FT_SNAPSHOT_DIR"], !p.isEmpty else { return nil }
+        return URL(fileURLWithPath: p)
+    }
+
+    /// Capture `win` to `<FT_SNAPSHOT_DIR>/<name>.png`. No-op when unset.
+    @discardableResult
+    static func take(_ win: NSWindow?, _ name: String) -> URL? {
+        guard let dir, let win else { return nil }
+        return write(win, to: dir.appendingPathComponent("\(name).png"))
+    }
+
+    /// Unconditional capture to an explicit file.
+    @discardableResult
+    static func write(_ win: NSWindow, to url: URL) -> URL? {
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        win.contentView?.layoutSubtreeIfNeeded()
+        win.displayIfNeeded()
+        // Let one turn of the run loop go by so CA commits the latest layer tree
+        // before the WindowServer is asked for the pixels.
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.15))
+        guard let rep = grab(win),
+              let data = rep.representation(using: .png, properties: [:]) else {
+            NSLog("Snapshot: could not capture window \(win.title) for \(url.lastPathComponent)")
+            return nil
+        }
+        do { try data.write(to: url) } catch { NSLog("Snapshot: write failed \(error)"); return nil }
+        print("  📸 \(url.path)")
+        return url
+    }
+
+    private static func grab(_ win: NSWindow) -> NSBitmapImageRep? {
+        if win.windowNumber > 0,
+           let cg = CGWindowListCreateImage(.null, [.optionIncludingWindow],
+                                            CGWindowID(win.windowNumber), [.bestResolution, .boundsIgnoreFraming]) {
+            return NSBitmapImageRep(cgImage: cg)
+        }
+        // Fallback (window not yet registered with the server): cacheDisplay.
+        guard let v = win.contentView, v.bounds.width > 1, v.bounds.height > 1,
+              let rep = v.bitmapImageRepForCachingDisplay(in: v.bounds) else { return nil }
+        v.cacheDisplay(in: v.bounds, to: rep)
+        return rep
+    }
+
+    // MARK: - standalone mode
+
+    static func runStandalone(outDir: String, appDelegate: AppDelegate) {
+        let env = ProcessInfo.processInfo.environment
+        let out = URL(fileURLWithPath: outDir)
+        let path = env["FT_SNAPSHOT_PATH"] ?? FileManager.default.currentDirectoryPath
+        let themes = (env["FT_SNAPSHOT_THEMES"] ?? "rascal-light,rascal-dark")
+            .split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        let size = NSSize(width: Double(env["FT_SNAPSHOT_W"] ?? "") ?? 1200,
+                          height: Double(env["FT_SNAPSHOT_H"] ?? "") ?? 800)
+
+        let wc = BrowserWindowController(rootURL: URL(fileURLWithPath: path))
+        guard let win = wc.window else { print("Snapshot: no window"); exit(2) }
+        win.setContentSize(size)
+        park(win)
+        spin(1.5)   // directory load + first layout
+
+        let originalTheme = ThemeManager.shared.current.id
+        for id in themes {
+            if ThemeManager.shared.available.contains(where: { $0.id == id }) {
+                ThemeManager.shared.setTheme(id: id)
+                spin(0.4)
+                write(win, to: out.appendingPathComponent("browser-\(id).png"))
+            } else {
+                print("Snapshot: unknown theme '\(id)' — have \(ThemeManager.shared.available.map(\.id))")
+            }
+        }
+        ThemeManager.shared.setTheme(id: originalTheme)
+
+        // Settings window: build it directly (SettingsController.show() would
+        // center it on-screen and activate the app).
+        let settings = SettingsController()
+        if let sw = settings.window {
+            park(sw)
+            for section in SettingsController.Section.allCases {
+                settings.select(section)
+                spin(0.3)
+                write(sw, to: out.appendingPathComponent("settings-\(section.rawValue).png"))
+            }
+            sw.orderOut(nil)
+        }
+        win.orderOut(nil)
+        exit(0)
+    }
+
+    private static func park(_ w: NSWindow) {
+        w.setFrameOrigin(NSPoint(x: -60000, y: -60000))
+        w.makeKeyAndOrderFront(nil)
+        w.setFrameOrigin(NSPoint(x: -60000, y: -60000))
+    }
+    private static func spin(_ s: TimeInterval) { RunLoop.current.run(until: Date(timeIntervalSinceNow: s)) }
+}

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -30,6 +30,7 @@ final class TestRunner {
 
         // --- T1: directory loads ---
         let items = pane.testCurrentItems
+        Snapshot.take(wc.window, "01-sandbox-loaded")
         assert("loads sandbox dir", items.count >= 4, "got \(items.count)")
 
         // --- T2: navigate into subdir ---
@@ -42,6 +43,7 @@ final class TestRunner {
         assert("subdir contents",
                pane.testCurrentItems.contains(where: { $0.name == "nested_file.txt" }),
                "items=\(pane.testCurrentItems.map { $0.name })")
+        Snapshot.take(wc.window, "02-subdir")
         // P1 guard: local volumes are detected as local, so navigation loads
         // synchronously (instant). Network mounts would load async to avoid
         // freezing the main thread on a slow/wedged share.
@@ -2128,6 +2130,7 @@ final class TestRunner {
                "filter changed: \(pane.testModel.filterText)")
         assert("File list focused on Return", pane.view.window?.firstResponder === pane.testFileList.tableView,
                "file list not focused")
+        Snapshot.take(wc.window, "03-vim-filter-accepted")
         
         // Check that Esc cancels search and returns focus to the file list
         pane.testFocusSearchField()

--- a/Sources/FinderTwo/UI/SettingsController.swift
+++ b/Sources/FinderTwo/UI/SettingsController.swift
@@ -63,7 +63,7 @@ final class SettingsController: NSWindowController, NSToolbarDelegate, ThemeObse
     }
     required init?(coder: NSCoder) { fatalError() }
 
-    private func select(_ section: Section) {
+    func select(_ section: Section) {
         current = section
         let vc = section.makeController()
         window?.contentViewController = vc

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# snapshot.sh — render Rascal's UI to PNGs entirely off-screen, so you can
+# check a visual change without a second monitor or the app stealing focus.
+#
+#   ./snapshot.sh                 # browser window at $HOME, light + dark, + Settings panes
+#   ./snapshot.sh ~/Downloads     # browser window at a specific folder
+#   FT_SNAPSHOT_THEMES=rascal-dark ./snapshot.sh   # one theme
+#   FT_SNAPSHOT_W=900 FT_SNAPSHOT_H=600 ./snapshot.sh
+#
+# Output: build/snapshots/*.png (dir is wiped each run). Also, smoketest.sh
+# will drop state screenshots into build/snapshots/smoke/ if you run it with
+# FT_SNAPSHOT_DIR set:  FT_SNAPSHOT_DIR=build/snapshots/smoke ./smoketest.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BIN="$ROOT/build/Rascal.app/Contents/MacOS/FinderTwo"
+OUT="${FT_SNAPSHOT_OUT:-$ROOT/build/snapshots}"
+TARGET="${1:-$HOME}"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "Binary not built. Run ./build.sh first."
+    exit 1
+fi
+
+rm -rf "$OUT"; mkdir -p "$OUT"
+pkill -f "$BIN" 2>/dev/null || true
+sleep 0.3
+
+FT_HEADLESS_TESTING=1 FT_SNAPSHOT="$OUT" FT_SNAPSHOT_PATH="$TARGET" "$BIN"
+status=$?
+echo
+ls -1 "$OUT"/*.png 2>/dev/null || echo "no snapshots produced"
+exit $status


### PR DESCRIPTION
## Summary
- New `Snapshot` helper captures any of Rascal's own windows off-screen via `CGWindowListCreateImage` (pixel-exact, vibrancy included, no Screen Recording permission, nothing ever appears on a display).
- `./snapshot.sh [folder]` — opens a real browser window at a folder, captures it in `rascal-light` + `rascal-dark`, then every Settings pane → `build/snapshots/*.png`. Knobs: `FT_SNAPSHOT_THEMES`, `FT_SNAPSHOT_W/H`.
- `FT_SNAPSHOT_DIR=<dir> ./smoketest.sh` — TestRunner drops state PNGs (`01-sandbox-loaded`, `02-subdir`, `03-vim-filter-typed`). No-op when unset. Add more with one line: `Snapshot.take(wc.window, "name")`.
- `SettingsController.select` made internal (standalone mode pages through sections).

## Why
Verifying visual changes previously meant running the app on-screen. This gives a headless loop: `./build.sh && ./snapshot.sh` and look at the PNGs. Already caught the search-field magnifier overlap that #21 fixed while I was testing on the old base.

## Testing
- `./build.sh` ✓
- `./smoketest.sh` → 605 passed, 0 failed (unchanged without the env var)
- `FT_SNAPSHOT_DIR=… ./smoketest.sh` and `./snapshot.sh` both produce correct PNGs, nothing appeared on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHKc4fHR8ha3TzcZeKmkxr