### PR TITLE
Fix: accurate transfer progress (logical bytes)

### DIFF
--- a/Sources/FinderTwo/Model/TransferQueue.swift
+++ b/Sources/FinderTwo/Model/TransferQueue.swift
@@ -39,6 +39,12 @@ final class TransferOp {
             lock.lock()
             let was = _state
             _state = newValue
+            // A successful terminal state is authoritative. Keep counters
+            // consistent with it so a completed row can never retain a partial
+            // progress bar because metadata changed during the transfer.
+            if newValue == .done {
+                _bytesDone = max(_bytesDone, _totalBytes)
+            }
             if newValue == .running {
                 if _startedAt == nil { _startedAt = Date() }
             } else if was == .running, let s = _startedAt {
@@ -141,16 +147,7 @@ final class TransferQueue {
         nextId += 1
         ops.append(op)
         lock.unlock()
-        
-        let opCopy = op
-        DispatchQueue.global(qos: .userInitiated).async {
-            let bytes = plan.reduce(0) { $0 + Self.size(of: $1.src) }
-            DispatchQueue.main.async {
-                opCopy.totalBytes = bytes
-                self.notify(force: true)
-            }
-        }
-        
+
         notify(force: true)
         kick()
         return op
@@ -210,10 +207,15 @@ final class TransferQueue {
     }
 
     private func run(_ op: TransferOp) {
+        // Measure on the serial worker before any move can rename/delete a
+        // source. Use logical bytes because streamed copies increment progress
+        // by bytes read, not by allocated disk blocks.
+        let plannedBytes = op.plan.map { Self.size(of: $0.src) }
+        op.totalBytes = plannedBytes.reduce(0, +)
         op.state = .running; notify(force: true)
         // Successfully-completed, non-merge steps, for undo registration.
         var done: [(src: URL, dst: URL)] = []
-        for step in op.plan {
+        for (step, stepBytes) in zip(op.plan, plannedBytes) {
             if op.cancelFlag.value { break }
             waitWhilePaused(op)
             if op.cancelFlag.value { break }
@@ -221,10 +223,10 @@ final class TransferQueue {
             var ok = true
             if step.merge {
                 ok = FileOps.mergeDirectory(src: step.src, into: step.dst, move: op.move) == 0
-                op.bytesDone += Self.size(of: step.dst)
+                if ok { op.bytesDone += stepBytes }
             } else if op.move && sameVolume(step.src, step.dst) {
                 ok = (try? fm.moveItem(at: step.src, to: step.dst)) != nil
-                op.bytesDone += Self.size(of: step.dst)
+                if ok { op.bytesDone += stepBytes }
             } else if isDir(step.src) {
                 ok = copyTree(step.src, into: step.dst, op: op)
                 if ok && op.move { try? fm.removeItem(at: step.src) }
@@ -348,7 +350,21 @@ final class TransferQueue {
 
     static func size(of url: URL) -> Int64 {
         let rv = try? url.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey])
-        if rv?.isDirectory == true { return FileListController.recursiveSize(url) }
+        if rv?.isDirectory == true {
+            var total: Int64 = 0
+            let keys: Set<URLResourceKey> = [.isDirectoryKey, .fileSizeKey]
+            if let entries = FileManager.default.enumerator(
+                at: url, includingPropertiesForKeys: Array(keys), options: []
+            ) {
+                while let entry = entries.nextObject() as? URL {
+                    let values = try? entry.resourceValues(forKeys: keys)
+                    if values?.isDirectory != true {
+                        total += Int64(values?.fileSize ?? 0)
+                    }
+                }
+            }
+            return total
+        }
         return Int64(rv?.fileSize ?? 0)
     }
 

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -306,6 +306,27 @@ final class TestRunner {
         assert("queue runs a copy to completion", qop.state == .done, "state=\(qop.state)")
         assert("queued streamed copy is byte-identical", (try? Data(contentsOf: tqOut)) == tqBytes, "bytes differ")
         assert("queue reports full progress", qop.fraction >= 0.999, "frac=\(qop.fraction)")
+        // Folder totals must use the same logical-byte unit as streamed copy
+        // progress. Allocated-size totals leave completed small-file copies with
+        // visibly partial bars.
+        let tqFolder = tqDir.appendingPathComponent("folder")
+        try? FileManager.default.createDirectory(at: tqFolder, withIntermediateDirectories: true)
+        mk(tqFolder.appendingPathComponent("small-a.txt"), "a")
+        mk(tqFolder.appendingPathComponent("small-b.txt"), "bc")
+        let tqFolderOut = tqDir.appendingPathComponent("folder-out")
+        let folderOp = TransferQueue.shared.enqueue(plan: [(tqFolder, tqFolderOut, false)], move: false)
+        waitUntil(5) { folderOp.state == .done }
+        assert("folder queue totals logical bytes", folderOp.totalBytes == 3, "total=\(folderOp.totalBytes)")
+        assert("completed folder queue counts all bytes", folderOp.bytesDone == 3, "done=\(folderOp.bytesDone)")
+        assert("completed folder queue shows full progress", folderOp.fraction >= 0.999, "frac=\(folderOp.fraction)")
+        // Terminal success remains authoritative if source metadata changes
+        // between sizing and completion.
+        let terminalOp = TransferOp(id: 2, move: false, plan: [])
+        terminalOp.totalBytes = 10
+        terminalOp.bytesDone = 6
+        terminalOp.state = .done
+        assert("done state normalizes progress to full", terminalOp.bytesDone == 10 && terminalOp.fraction == 1,
+               "done=\(terminalOp.bytesDone), frac=\(terminalOp.fraction)")
         // pause flag toggles
         TransferQueue.shared.setPaused(true)
         assert("queue pause flag sets", TransferQueue.shared.isPaused, "not paused")


### PR DESCRIPTION
Completed folder transfers could retain a partial progress bar: the transfer total was computed from **allocated disk blocks** while progress counted **logical file bytes**, so progress never reached the total for sparse/compressed files. Count both in logical bytes.

Split out from community PR #19 by @zz999dev (closed there to land as independent fixes) — thanks!

Includes the TestRunner coverage from the original commit. Headed VM verification + recording to follow in a comment.