### PR TITLE
Path bar position: top or bottom (Finder-style)

### DIFF
--- a/Sources/FinderTwo/Model/Settings.swift
+++ b/Sources/FinderTwo/Model/Settings.swift
@@ -164,6 +164,22 @@ enum Settings {
         set { d.set(newValue.rawValue, forKey: "FinderTwo.pathControlStyle"); notifyAppearance() }
     }
 
+    enum PathBarPosition: String, CaseIterable {
+        case top
+        case bottom
+
+        var label: String { rawValue.capitalized }
+    }
+
+    /// Place the breadcrumb above pane content or along the bottom edge,
+    /// directly above the status bar. Finder-style bottom placement is default.
+    static var pathBarPosition: PathBarPosition {
+        get {
+            PathBarPosition(rawValue: d.string(forKey: "FinderTwo.pathBarPosition") ?? "") ?? .bottom
+        }
+        set { d.set(newValue.rawValue, forKey: "FinderTwo.pathBarPosition"); notify() }
+    }
+
     /// Compute and show recursive folder sizes in the Size column (Finder's
     /// "Calculate all sizes"). Off by default — it's I/O-heavy.
     static var calculateFolderSizes: Bool {
@@ -298,6 +314,7 @@ enum Settings {
                     "FinderTwo.density", "FinderTwo.fontSizeDelta", "FinderTwo.accent",
                     "FinderTwo.typeAhead", "FinderTwo.showHotbar", "FinderTwo.showTitleBar",
                     "FinderTwo.typeToSelect", "FinderTwo.showStatusBar", "FinderTwo.showPathBar",
+                    "FinderTwo.pathBarPosition",
                     "FinderTwo.springLoadedFolders", "FinderTwo.springLoadDelay",
                     "FinderTwo.useGroups",
                     "FinderTwo.gitIntegrationEnabled", "FinderTwo.showGitBranchInStatusBar",

--- a/Sources/FinderTwo/Tests/TestRunner.swift
+++ b/Sources/FinderTwo/Tests/TestRunner.swift
@@ -1388,12 +1388,21 @@ final class TestRunner {
         pane.navigate(to: sandbox); pane.testReloadSync()
 
         // --- T42g: view/layout setting defaults ---
-        for k in ["FinderTwo.typeToSelect", "FinderTwo.showStatusBar", "FinderTwo.showPathBar"] {
+        for k in ["FinderTwo.typeToSelect", "FinderTwo.showStatusBar", "FinderTwo.showPathBar",
+                  "FinderTwo.pathBarPosition"] {
             UserDefaults.standard.removeObject(forKey: k)
         }
         assert("typeToSelect defaults off", Settings.typeToSelect == false, "got \(Settings.typeToSelect)")
         assert("showStatusBar defaults on", Settings.showStatusBar == true, "got \(Settings.showStatusBar)")
         assert("showPathBar defaults on", Settings.showPathBar == true, "got \(Settings.showPathBar)")
+        assert("pathBarPosition defaults to bottom", Settings.pathBarPosition == .bottom,
+               "got \(Settings.pathBarPosition)")
+        Settings.pathBarPosition = .top; wait(0.02)
+        assert("path bar moves to top live", pane.testPathBarPosition == .top,
+               "got \(pane.testPathBarPosition)")
+        Settings.pathBarPosition = .bottom; wait(0.02)
+        assert("path bar moves to bottom live", pane.testPathBarPosition == .bottom,
+               "got \(pane.testPathBarPosition)")
 
         // --- T42g2: spring-loaded folder settings ---
         for k in ["FinderTwo.springLoadedFolders", "FinderTwo.springLoadDelay"] {

--- a/Sources/FinderTwo/UI/PaneController.swift
+++ b/Sources/FinderTwo/UI/PaneController.swift
@@ -51,6 +51,8 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     private var hotbarHeightConstraint: NSLayoutConstraint!
     private var pathBarHeightConstraint: NSLayoutConstraint!
     private var statusBarHeightConstraint: NSLayoutConstraint!
+    private var topPathBarConstraints: [NSLayoutConstraint] = []
+    private var bottomPathBarConstraints: [NSLayoutConstraint] = []
     /// Inset for the first row of pane content. Non-zero when the window title
     /// bar is hidden, so the toolbar clears the traffic-light strip and lines up
     /// with the (also-inset) sidebar.
@@ -260,6 +262,16 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
         pathBarHeightConstraint = pathBar.heightAnchor.constraint(equalToConstant: 26)
         statusBarHeightConstraint = statusBar.heightAnchor.constraint(equalToConstant: 22)
         topInsetConstraint = toolbar.topAnchor.constraint(equalTo: root.topAnchor)
+        topPathBarConstraints = [
+            pathBar.topAnchor.constraint(equalTo: tabStrip.bottomAnchor),
+            hotbar.topAnchor.constraint(equalTo: pathBar.bottomAnchor),
+            terminalView.bottomAnchor.constraint(equalTo: statusBar.topAnchor),
+        ]
+        bottomPathBarConstraints = [
+            hotbar.topAnchor.constraint(equalTo: tabStrip.bottomAnchor),
+            terminalView.bottomAnchor.constraint(equalTo: pathBar.topAnchor),
+            pathBar.bottomAnchor.constraint(equalTo: statusBar.topAnchor),
+        ]
 
         NSLayoutConstraint.activate([
             topInsetConstraint,
@@ -272,12 +284,6 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
             tabStrip.trailingAnchor.constraint(equalTo: root.trailingAnchor),
             tabStripHeightConstraint,
 
-            pathBar.topAnchor.constraint(equalTo: tabStrip.bottomAnchor),
-            pathBar.leadingAnchor.constraint(equalTo: root.leadingAnchor),
-            pathBar.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-            pathBarHeightConstraint,
-
-            hotbar.topAnchor.constraint(equalTo: pathBar.bottomAnchor),
             hotbar.leadingAnchor.constraint(equalTo: root.leadingAnchor),
             hotbar.trailingAnchor.constraint(equalTo: root.trailingAnchor),
             hotbarHeightConstraint,
@@ -306,7 +312,6 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
 
             terminalView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
             terminalView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-            terminalView.bottomAnchor.constraint(equalTo: statusBar.topAnchor),
             terminalHeightConstraint,
 
             emptyState.topAnchor.constraint(equalTo: fileList.view.topAnchor),
@@ -314,11 +319,17 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
             emptyState.trailingAnchor.constraint(equalTo: fileList.view.trailingAnchor),
             emptyState.bottomAnchor.constraint(equalTo: fileList.view.bottomAnchor),
 
+            pathBar.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            pathBar.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            pathBarHeightConstraint,
+
             statusBar.leadingAnchor.constraint(equalTo: root.leadingAnchor),
             statusBar.trailingAnchor.constraint(equalTo: root.trailingAnchor),
             statusBar.bottomAnchor.constraint(equalTo: root.bottomAnchor),
             statusBarHeightConstraint,
         ])
+        NSLayoutConstraint.activate(Settings.pathBarPosition == .top
+                                    ? topPathBarConstraints : bottomPathBarConstraints)
 
         toolbar.onBack = { [weak self] in self?.goBack() }
         toolbar.onForward = { [weak self] in self?.goForward() }
@@ -371,11 +382,18 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     private func applyChromeVisibility() {
         let style = Settings.pathControlStyle
         let showCrumbs = (style == .breadcrumb || style == .both)
+        applyPathBarPosition()
         pathBar.isHidden = !showCrumbs
         pathBarHeightConstraint.constant = showCrumbs ? 26 : 0
         toolbar.setPathFieldVisible(style == .editableField || style == .both)
         statusBar.isHidden = !Settings.showStatusBar
         statusBarHeightConstraint.constant = Settings.showStatusBar ? 22 : 0
+    }
+
+    private func applyPathBarPosition() {
+        NSLayoutConstraint.deactivate(topPathBarConstraints + bottomPathBarConstraints)
+        NSLayoutConstraint.activate(Settings.pathBarPosition == .top
+                                    ? topPathBarConstraints : bottomPathBarConstraints)
     }
 
     /// Pin the toolbar to the top of the pane. The window's traffic lights sit at
@@ -1152,6 +1170,9 @@ final class PaneController: NSViewController, DirectoryModelDelegate, FileListDe
     var testPreviewHasQLView: Bool { previewView.testHasLiveQLView }
     var testHotbarHeight: CGFloat { hotbarHeightConstraint.constant }
     var testToolbarTopInset: CGFloat { topInsetConstraint.constant }
+    var testPathBarPosition: Settings.PathBarPosition {
+        topPathBarConstraints.allSatisfy(\.isActive) ? .top : .bottom
+    }
     func testToolbarHasFocusAPI() -> Bool {
         // Compile-time presence — calling shouldn't crash.
         toolbar.focusSearchField()

--- a/Sources/FinderTwo/UI/SettingsController.swift
+++ b/Sources/FinderTwo/UI/SettingsController.swift
@@ -176,6 +176,8 @@ class SettingsPane: NSViewController, ThemeObserving {
 // MARK: - General
 
 final class GeneralPane: SettingsPane {
+    private let pathBarPosition = NSPopUpButton()
+
     override func build() {
         let loc = NSPopUpButton()
         for l in Settings.DefaultLocation.allCases { loc.addItem(withTitle: l.label); loc.lastItem?.representedObject = l.rawValue }
@@ -223,7 +225,15 @@ final class GeneralPane: SettingsPane {
         pathBar.state = Settings.showPathBar ? .on : .off
         addRow("", pathBar)
 
-
+        for position in Settings.PathBarPosition.allCases {
+            pathBarPosition.addItem(withTitle: position.label)
+            pathBarPosition.lastItem?.representedObject = position.rawValue
+        }
+        pathBarPosition.selectItem(withTitle: Settings.pathBarPosition.label)
+        pathBarPosition.target = self
+        pathBarPosition.action = #selector(pathBarPositionChanged(_:))
+        pathBarPosition.isEnabled = Settings.showPathBar
+        addRow("Path bar position:", pathBarPosition)
 
         let alwaysShowTab = NSButton(checkboxWithTitle: "Always show tab bar",
                                      target: self, action: #selector(alwaysShowTabChanged(_:)))
@@ -239,7 +249,15 @@ final class GeneralPane: SettingsPane {
     @objc private func foldersTopChanged(_ s: NSButton) { Settings.foldersFirst = s.state == .on }
     @objc private func titleBarChanged(_ s: NSButton) { Settings.showTitleBar = s.state == .on }
     @objc private func statusBarChanged(_ s: NSButton) { Settings.showStatusBar = s.state == .on }
-    @objc private func pathBarChanged(_ s: NSButton) { Settings.showPathBar = s.state == .on }
+    @objc private func pathBarChanged(_ s: NSButton) {
+        Settings.showPathBar = s.state == .on
+        pathBarPosition.isEnabled = Settings.showPathBar
+    }
+    @objc private func pathBarPositionChanged(_ s: NSPopUpButton) {
+        guard let raw = s.selectedItem?.representedObject as? String,
+              let position = Settings.PathBarPosition(rawValue: raw) else { return }
+        Settings.pathBarPosition = position
+    }
     @objc private func alwaysShowTabChanged(_ s: NSButton) { Settings.alwaysShowTabBar = s.state == .on }
     @objc private func doubleClickTabChanged(_ s: NSButton) { Settings.doubleClickFolderOpensNewTab = s.state == .on }
 


### PR DESCRIPTION
The breadcrumb path bar can now sit above the pane content or along the bottom edge, directly above the status bar (Finder-style bottom is the commit's default placement).

Resolved against `main`'s newer `pathControlStyle` setting (#17): the position option composes with it — position applies whenever breadcrumbs are visible (`breadcrumb`/`both` styles).

Split out from community PR #19 by @zz999dev (closed there to land as independent fixes) — thanks!

Headed VM verification + recording to follow in a comment.